### PR TITLE
Change webpack.config.js to webpack.haul.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@
 npm install --save-dev haul-cli
 ```
 
-then, create `webpack.config.js` in your root and specify an entry point of your app:
+then, create `webpack.haul.js` in your root and specify an entry point of your app:
 
 ```js
 module.exports = {
   entry: './index.js',
 };
 ```
-By default, React Native app has two entry points: `index.ios.js` and `index.android.js`. In such case, you can change your `webpack.config.js` to be a function:
+By default, React Native app has two entry points: `index.ios.js` and `index.android.js`. In such case, you can change your `webpack.haul.js` to be a function:
 
 ```js
 module.exports = ({ platform }) => ({

--- a/src/cli/start/index.js
+++ b/src/cli/start/index.js
@@ -23,7 +23,7 @@ import type { CommandArgs } from '../../types';
  * Starts development server
  */
 function start(argv: CommandArgs, opts: *) {
-  const configPath = path.join(process.cwd(), 'webpack.config.js');
+  const configPath = path.join(process.cwd(), 'webpack.haul.js');
 
   if (!fs.existsSync(configPath)) {
     throw new Error(

--- a/src/messages/webpackConfigNotFound.js
+++ b/src/messages/webpackConfigNotFound.js
@@ -12,7 +12,7 @@ const chalk = require('chalk');
 module.exports = ({ path }: { path: string }) => dedent`
    Webpack config wasn't found at ${path}.
 
-   Make sure you have appropriate webpack.config.js. 
+   Make sure you have appropriate webpack.haul.js. 
    
    You can copy the following simplified version to set it up now:
    ${chalk.gray(`

--- a/src/utils/makeReactNativeConfig.js
+++ b/src/utils/makeReactNativeConfig.js
@@ -39,7 +39,7 @@ const getDefaultConfig = ({ platform, cwd, dev, port }): WebpackConfig => ({
   module: {
     rules: [
       {
-        test: /\.jsx?$/,
+        test: /\.js$/,
         loader: 'happypack/loader?id=babel',
         exclude: /node_modules\/(?!react)/
       },


### PR DESCRIPTION
It's not really a webpack.config.js that can work with e.g. webpack CLI, so it's better to name it `haul`.

We also remove support for `jsx`. Once can define custom webpack loader to support it.