### PR TITLE
Use resolver plugin instead of alias

### DIFF
--- a/src/resolvers/HasteResolver.js
+++ b/src/resolvers/HasteResolver.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2017-present, Callstack.
+ * All rights reserved.
+ *
+ * @flow
+ */
+type Request = {
+  request?: string,
+};
+
+type Options = {
+  directories: Array<string>,
+};
+
+const findProvidesModule = require('../utils/findProvidesModule');
+
+/**
+ * Resolver plugin that allows requiring haste modules with Webpack
+ */
+function HasteResolver(options: Options) {
+  const hasteMap = findProvidesModule(options.directories);
+
+  this.apply = resolver => {
+    resolver.plugin(
+      'described-resolve',
+      (request: Request, callback: Function) => {
+        const innerRequest = request.request;
+
+        if (!innerRequest || !hasteMap[innerRequest]) {
+          return callback();
+        }
+
+        const obj = Object.assign({}, request, {
+          request: hasteMap[innerRequest],
+        });
+
+        return resolver.doResolve(
+          'resolve',
+          obj,
+          `Aliased ${innerRequest} with haste mapping: ${hasteMap[innerRequest]}`,
+          callback,
+        );
+      },
+    );
+  };
+}
+
+module.exports = HasteResolver;

--- a/src/utils/makeReactNativeConfig.js
+++ b/src/utils/makeReactNativeConfig.js
@@ -10,8 +10,9 @@ const webpack = require('webpack');
 const HappyPack = require('happypack');
 const path = require('path');
 const ProgressBarPlugin = require('progress-bar-webpack-plugin');
+
 const AssetResolver = require('../resolvers/AssetResolver');
-const findProvidesModule = require('./findProvidesModule');
+const HasteResolver = require('../resolvers/HasteResolver');
 
 const PLATFORMS = ['ios', 'android'];
 
@@ -98,8 +99,12 @@ const getDefaultConfig = ({ platform, cwd, dev, bundle }): WebpackConfig => ({
   ],
   // Default resolve
   resolve: {
-    plugins: [new AssetResolver({ platform })],
-    alias: findProvidesModule([path.resolve(cwd, 'node_modules/react-native')]),
+    plugins: [
+      new HasteResolver({
+        directories: [path.resolve(cwd, 'node_modules/react-native')],
+      }),
+      new AssetResolver({ platform }),
+    ],
     mainFields: ['browser', 'main'],
     extensions: [`.${platform}.js`, '.native.js', '.js'],
   },


### PR DESCRIPTION
Replaced alias with a custom plugin.

One benefit that we gain here is that Webpack registers `n` plugins for `n` aliases - every `alias` is a standalone plugin. That results in a lot of calls. 

Here, we rely on a single one.