### PR TITLE
Handle situation when server port is in use

### DIFF
--- a/src/cliEntry.js
+++ b/src/cliEntry.js
@@ -12,7 +12,7 @@ const clear = require('clear');
 const inquirer = require('inquirer');
 const path = require('path');
 const chalk = require('chalk');
-const { isPortTaken, killHaulProcess } = require('./utils/haulPortHandler');
+const { isPortTaken, killProcess } = require('./utils/haulPortHandler');
 
 const pjson = require('../package.json');
 const logger = require('./logger');
@@ -184,7 +184,7 @@ async function run(args: Array<string>) {
         ],
       });
       if (userChoice === 'Quit') return;
-      const result = await killHaulProcess(options.port);
+      const result = await killProcess(options.port);
       if (!result) {
         logger.error(`Could not kill process! Aborting.`);
         return;

--- a/src/cliEntry.js
+++ b/src/cliEntry.js
@@ -12,7 +12,6 @@ const clear = require('clear');
 const inquirer = require('inquirer');
 const path = require('path');
 const chalk = require('chalk');
-const { isPortTaken, killProcess } = require('./utils/haulPortHandler');
 
 const pjson = require('../package.json');
 const logger = require('./logger');
@@ -170,28 +169,6 @@ async function run(args: Array<string>) {
   const { options, promptedOptions } = await validateOptions(opts, flags);
   const userDefinedOptions = { ...flags, ...promptedOptions };
   const displayName = getDisplayName(command.name, userDefinedOptions);
-
-  if (command.name === 'start') {
-    const isTaken = await isPortTaken(options.port);
-    if (isTaken) {
-      const { userChoice } = await inquirer.prompt({
-        type: 'list',
-        name: 'userChoice',
-        message: `Port ${options.port} is already in use. What should we do?`,
-        choices: [
-          `Kill process using port ${options.port} and start server`,
-          'Quit',
-        ],
-      });
-      if (userChoice === 'Quit') return;
-      const result = await killProcess(options.port);
-      if (!result) {
-        logger.error(`Could not kill process! Aborting.`);
-        return;
-      }
-      logger.info(`Successfully killed processes.`);
-    }
-  }
 
   if (Object.keys(promptedOptions).length) {
     logger.info(`Running ${chalk.cyan(displayName)}`);

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -7,12 +7,14 @@
 const webpack = require('webpack');
 const path = require('path');
 const clear = require('clear');
+const inquirer = require('inquirer');
 
 const logger = require('../logger');
 const createServer = require('../server');
 const messages = require('../messages');
 const exec = require('../utils/exec');
 const getWebpackConfig = require('../utils/getWebpackConfig');
+const { isPortTaken, killProcess } = require('../utils/haulPortHandler');
 
 const makeReactNativeConfig = require('../utils/makeReactNativeConfig');
 
@@ -20,6 +22,26 @@ const makeReactNativeConfig = require('../utils/makeReactNativeConfig');
  * Starts development server
  */
 async function start(opts: *) {
+  const isTaken = await isPortTaken(opts.port);
+  if (isTaken) {
+    const { userChoice } = await inquirer.prompt({
+      type: 'list',
+      name: 'userChoice',
+      message: `Port ${opts.port} is already in use. What should we do?`,
+      choices: [`Kill process using port ${opts.port} and start Haul`, 'Quit'],
+    });
+    if (userChoice === 'Quit') {
+      process.exit();
+    }
+    try {
+      await killProcess(opts.port);
+    } catch (e) {
+      logger.error(`Could not kill process! Reason: \n ${e.message}`);
+      process.exit(1);
+    }
+    logger.info(`Successfully killed processes.`);
+  }
+
   const directory = process.cwd();
   const configPath = getWebpackConfig(directory, opts.config);
 

--- a/src/utils/haulPortHandler.js
+++ b/src/utils/haulPortHandler.js
@@ -19,11 +19,8 @@ function isPortTaken(port: number) {
         return resolve(true);
       })
       .once('listening', () => {
-        portTester
-          .once('close', () => {
-            resolve(false);
-          })
-          .close();
+        portTester.close();
+        resolve(false);
       })
       .listen(port);
   });
@@ -52,8 +49,8 @@ function killProcess(port: number) {
         return;
       }
       /* 
-       * If no error, that means port is in use 
-       * And this port is used only by one process
+       * If no error, port is in use 
+       * And that port is used only by one process
        */
       const PIDInfo = stdout
         .trim()
@@ -71,11 +68,8 @@ function killProcess(port: number) {
       /*
        * Kill process
        */
-      try {
-        process.kill(PID);
-      } catch (e) {
-        resolve(false);
-      }
+      process.kill(PID);
+
       resolve(true);
     });
   });

--- a/src/utils/haulPortHandler.js
+++ b/src/utils/haulPortHandler.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2017-present, Callstack.
+ * All rights reserved.
+ *
+ * @flow
+ */
+
+const net = require('net');
+const exec = require('child_process').exec;
+
+/*
+ * Check if the port is already in use
+ */
+
+function isPortTaken(port: number) {
+  return new Promise(resolve => {
+    const portTester = net
+      .createServer()
+      .once('error', () => {
+        return resolve(true);
+      })
+      .once('listening', () => {
+        portTester
+          .once('close', () => {
+            resolve(false);
+          })
+          .close();
+      })
+      .listen(port);
+  });
+}
+
+function killHaulProcess(port: number) {
+  return new Promise(resolve => {
+    /*
+     * Find PID that is listening at given port
+     */
+    exec(`lsof -n -i:${port} | grep LISTEN`, (error, stdout) => {
+      if (error) {
+        resolve(false);
+      }
+      const PIDList = stdout.trim().split('\n');
+
+      /* There can be only one PID using PORT */
+      if (PIDList.length) {
+        /* PID is placed at index 1, 0 is process name */
+        const PID = PIDList[0].split(' ').filter(pidInfo => pidInfo)[1];
+        /*
+         * Kill Haul process
+         */
+        try {
+          process.kill(PID);
+        } catch (e) {
+          resolve(false);
+        }
+        resolve(true);
+      }
+      resolve(false);
+    });
+  });
+}
+
+module.exports = {
+  isPortTaken,
+  killHaulProcess,
+};


### PR DESCRIPTION
This feature gives user a choice what to do when server port (default) 8081 is already in use. We can kill the process that uses the port and proceed with startup or simply quit.
Fix for #207 


- [X] Tested on macOS
- [x] Tested on Linux
- [x] Windows implementation
- [x] Tested on Windows