### PR TITLE
Support multiple files in webpack config

### DIFF
--- a/src/commands/bundle.js
+++ b/src/commands/bundle.js
@@ -64,8 +64,21 @@ async function bundle(opts: *) {
   const stats = await new Promise((resolve, reject) =>
     compiler.run((err, info) => {
       if (err || info.hasErrors()) {
+        if (err) {
+          logger.error(err);
+        }
+        if (info && info.hasWarnings()) {
+          info.toJson().warnings.map(warning => logger.warn(warning));
+        }
+        if (info && info.hasErrors()) {
+          info.toJson().errors.map(error => logger.error(error));
+        }
+
         reject(new MessageError(messages.bundleFailed()));
       } else {
+        if (info && info.hasWarnings()) {
+          info.toJson().warnings.map(warning => logger.warn(warning));
+        }
         resolve(info);
       }
     }),

--- a/src/hot/client/importScriptsPolyfill.js
+++ b/src/hot/client/importScriptsPolyfill.js
@@ -16,7 +16,9 @@
 global.importScripts =
   global.importScripts ||
   (importPath =>
-    fetch(importPath).then(response => response.text()).then(body => {
-      // eslint-disable-next-line no-eval
-      eval(body);
-    }));
+    fetch(importPath)
+      .then(response => response.text())
+      .then(body => {
+        // eslint-disable-next-line no-eval
+        eval(body);
+      }));

--- a/src/messages/entryPointList.js
+++ b/src/messages/entryPointList.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2017-present, Callstack.
+ * All rights reserved.
+ *
+ * @flow
+ */
+const chalk = require('chalk');
+const path = require('path');
+
+type Params = {
+  entries: Array<Array<string>>,
+};
+
+function getEntryFiles(entry) {
+  if (Array.isArray(entry)) {
+    return [path.resolve(process.cwd(), entry[entry.length - 1])];
+  } else if (typeof entry === 'string') {
+    return [path.resolve(process.cwd(), entry)];
+  } else if (typeof entry === 'object') {
+    return Object.keys(entry)
+      .map(k => getEntryFiles(entry[k]))
+      .reduce((a, b) => a.concat(b), []);
+  }
+  return [String(entry)];
+}
+
+module.exports = (config: Params) =>
+  config.entries
+    .map(getEntryFiles)
+    .reduce((a, b) => a.concat(b), [])
+    .map(s => chalk.grey(s))
+    .join('\n');

--- a/src/messages/initialBundleInformation.js
+++ b/src/messages/initialBundleInformation.js
@@ -6,15 +6,11 @@
  */
 const dedent = require('dedent');
 const chalk = require('chalk');
-const path = require('path');
+const entryPointList = require('./entryPointList');
 
 type Params = {
   entry: Array<string>,
   dev: boolean,
-};
-
-const getEntryFile = (entries: Array<string>) => {
-  return path.resolve(process.cwd(), entries[entries.length - 1]);
 };
 
 module.exports = (config: Params) => {
@@ -22,9 +18,9 @@ module.exports = (config: Params) => {
 
   return dedent`
     Haul is now bundling your React Native app in ${chalk.bold(mode)} mode.
-    
+
     Starting from:
 
-    ${chalk.grey(getEntryFile(config.entry))} \n
+    ${entryPointList({ entries: [config.entry] })} \n
   `;
 };

--- a/src/messages/initialStartInformation.js
+++ b/src/messages/initialStartInformation.js
@@ -6,15 +6,11 @@
  */
 const dedent = require('dedent');
 const chalk = require('chalk');
-const path = require('path');
+const entryPointList = require('./entryPointList');
 
 type Params = {
   entries: Array<Array<string>>,
   port: number,
-};
-
-const getEntryFile = (entries: Array<string>) => {
-  return path.resolve(process.cwd(), entries[entries.length - 1]);
 };
 
 module.exports = (config: Params) => dedent`
@@ -22,7 +18,7 @@ module.exports = (config: Params) => dedent`
 
   Haul is now bundling your React Native app, starting from:
 
-  ${config.entries.map(e => chalk.grey(getEntryFile(e))).join('\n')}
+  ${entryPointList(config)}
 
   A fresh build may take longer than usual\n
 `;

--- a/src/utils/makeReactNativeConfig.js
+++ b/src/utils/makeReactNativeConfig.js
@@ -234,10 +234,13 @@ function makeReactNativeConfig(
         : userWebpackConfig,
     );
 
-    // For simplicity, we don't require users to extend
+    // For simplicity, we usually don't require users to extend
     // default config.entry but do it for them.
-    config.entry = defaultWebpackConfig.entry.concat(config.entry);
-
+    // For flexibility, the default does need to be added manually
+    // if multiple bundles are specified
+    if (Array.isArray(config.entry) || typeof config.entry === 'string') {
+      config.entry = defaultWebpackConfig.entry.concat(config.entry);
+    }
     return config;
   });
 


### PR DESCRIPTION
Adds support for webpack configs that generate multiple files in the form

    entry: {
        "package1": defaults.entry.concat("./package1.js"),
        "package2": defaults.entry.concat("./package2.js")
    },
    output: {
        path: path.join(__dirname, "dist"),
        filename: "[name].bundle"
    },

Also a couple of minor updates from debugging - lint issues that were blocking the tests and improved logging on bundle to catch minification  errors. 