### PR TITLE
Improve symbolicateMiddleware stackframe existence checks.

### DIFF
--- a/src/server/middleware/symbolicateMiddleware.js
+++ b/src/server/middleware/symbolicateMiddleware.js
@@ -118,7 +118,7 @@ function create(webpackCompiler: *): Middleware {
 
     // grab the source stack frames
     const unconvertedFrames = getRequestedFrames(req);
-    if (!unconvertedFrames) return next();
+    if (!unconvertedFrames || unconvertedFrames.length === 0) return next();
 
     // grab the platform from the first frame (e.g. index.ios.bundle?platform=ios&dev=true&minify=false:69825:16)
     const platformMatch = unconvertedFrames[0].file.match(


### PR DESCRIPTION
At the moment, `symbolicateMiddleware` expects [`getRequestedFrames`](https://github.com/callstack/haul/blob/master/src/server/middleware/symbolicateMiddleware.js#L73) to return `null` if something was wrong with the stack or a non-empty array of frames if all goes well. 

This leads to an error edge case where the code blows up if `getRequestedFrames` returns an empty array.

```
TypeError: Cannot read property 'file' of undefined
    at symbolicateMiddleware (MY_PATH/node_modules/haul/src/server/middleware/symbolicateMiddleware.js:124:27)
   ...
```

Because [this line](https://github.com/callstack/haul/blob/master/src/server/middleware/symbolicateMiddleware.js#L124) assumes it will operate on a non-empty array:

```js
const platformMatch = unconvertedFrames[0].file.match(/* ... */)
//                                     ^ breaks on empty array
```

This PR adds a simple check to fix it.