### PR TITLE
Set CORS header for remote debugging

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -52,7 +52,10 @@ function createServer(
     stats: 'errors-only',
     hot: true,
     mimeTypes: { 'application/javascript': ['bundle'] },
-    headers: { 'Content-Type': 'application/javascript' },
+    headers: {
+      'Content-Type': 'application/javascript',
+      'Access-Control-Allow-Origin': '*',
+    },
     watchOptions: {
       aggregateTimeout: 300,
       poll: 1000,


### PR DESCRIPTION
This will allow the remote debugger to make requests to the dev server when browser's remote debugger address and dev server address differ.