### PR TITLE
THIS_DIR in haul-integrate.sh returns relative path instead of absolute

### DIFF
--- a/src/utils/haul-integrate.sh
+++ b/src/utils/haul-integrate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-THIS_DIR=$(dirname $0)
+THIS_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
 SCRIPT_SRC="${THIS_DIR}/../../../react-native/packager"
 
@@ -15,5 +15,5 @@ SRC="$(cd "${SCRIPT_SRC}" && pwd)"
 sed -i -e 's|$REACT_NATIVE_DIR/local-cli/cli.js|./node_modules/.bin/haul|' ${SRC}/react-native-xcode.sh
 
 # Replace `react-native start` in `packager.sh`
-PACKAGER_CONTENT="cd \"$THIS_DIR/../../../\" && node \"./node_modules/.bin/haul\" start --platform ios \"\$@\""
+PACKAGER_CONTENT="cd \"$THIS_DIR/../../../../\" && node \"./node_modules/.bin/haul\" start --platform ios \"\$@\""
 echo "$PACKAGER_CONTENT" > ${SRC}/packager.sh


### PR DESCRIPTION
In the latest beta of haul we get the following error when the packager is started:

```
/Users/unixusername/Documents/project/projectname/node_modules/react-native/scripts/packager.sh: line 1: cd: ../node_modules/haul/src/utils/../../../: No such file or directory
```

To fix this `THIS_DIR` in `haul-packager.sh` should return an absolute path instead of relative path since the packager is started in a new shell.

Versions: 
OS: Mac OSX Sierra
haul v1.0.0-beta.6
react-native: 0.47.1
react: 16.0.0-alpha.12