### PR TITLE
chore: bump eslint callstack config

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "babel-jest": "test",
     "babel-preset-react-native": "^2.0.0",
     "eslint": "^4.3.0",
-    "eslint-config-callstack-io": "^0.5.0",
+    "eslint-config-callstack-io": "^1.0.1",
     "flow-bin": "^0.57.2",
     "husky": "^0.13.3",
     "jest": "test",

--- a/src/hot/client/importScriptsPolyfill.js
+++ b/src/hot/client/importScriptsPolyfill.js
@@ -16,7 +16,9 @@
 global.importScripts =
   global.importScripts ||
   (importPath =>
-    fetch(importPath).then(response => response.text()).then(body => {
-      // eslint-disable-next-line no-eval
-      eval(body);
-    }));
+    fetch(importPath)
+      .then(response => response.text())
+      .then(body => {
+        // eslint-disable-next-line no-eval
+        eval(body);
+      }));

--- a/src/messages/bundleBuilt.js
+++ b/src/messages/bundleBuilt.js
@@ -23,8 +23,8 @@ module.exports = ({
 }) => {
   const heading = stats.hasWarnings()
     ? chalk.yellow('Built with warnings')
-    : `Built successfully in ${(stats.toJson({ timing: true }).time /
-        1000).toFixed(2)}s!`;
+    : `Built successfully in ${(stats.toJson({ timing: true }).time / 1000
+      ).toFixed(2)}s!`;
 
   if (assetsPath && bundlePath) {
     return dedent`

--- a/yarn.lock
+++ b/yarn.lock
@@ -1698,24 +1698,24 @@ eslint-config-airbnb@^15.1.0:
   dependencies:
     eslint-config-airbnb-base "^11.3.0"
 
-eslint-config-callstack-io@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-callstack-io/-/eslint-config-callstack-io-0.5.0.tgz#c40bc72c541ab209eadd6c8a4d722e60d176252a"
+eslint-config-callstack-io@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-callstack-io/-/eslint-config-callstack-io-1.0.1.tgz#53f2ada95109ef8bf5c80dca7f2e7317a09cba43"
   dependencies:
     babel-eslint "^7.2.3"
     eslint-config-airbnb "^15.1.0"
-    eslint-config-prettier "^2.3.0"
+    eslint-config-prettier "^2.6.0"
     eslint-plugin-flowtype "^2.35.0"
     eslint-plugin-import "^2.7.0"
     eslint-plugin-jest "^20.0.3"
     eslint-plugin-jsx-a11y "^5.1.1"
     eslint-plugin-prettier "^2.1.2"
     eslint-plugin-react "^7.1.0"
-    prettier "^1.5.3"
+    prettier "^1.7.4"
 
-eslint-config-prettier@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.3.0.tgz#b75b1eabea0c8b97b34403647ee25db349b9d8a0"
+eslint-config-prettier@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.6.0.tgz#f21db0ebb438ad678fb98946097c4bb198befccc"
   dependencies:
     get-stdin "^5.0.1"
 
@@ -3813,9 +3813,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.5.3:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.5.3.tgz#59dadc683345ec6b88f88b94ed4ae7e1da394bfe"
+prettier@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.4.tgz#5e8624ae9363c80f95ec644584ecdf55d74f93fa"
 
 pretty-format@21.0.0-alpha.1:
   version "21.0.0-alpha.1"


### PR DESCRIPTION
I've just released a major bump of the `eslint-config-callstack-io`, so here it is.