### PR TITLE
Use quotation marks for HTML param values

### DIFF
--- a/src/server/assets/debugger.html
+++ b/src/server/assets/debugger.html
@@ -3,7 +3,7 @@
 <html>
 
 <head>
-  <meta charset=utf-8>
+  <meta charset="utf-8">
 
   <link rel="icon" type="image/png" href="haul_icon.ico" />
 
@@ -280,14 +280,14 @@
       <img src="haul_logo.png" alt="Haul logo">
     </div>
 
-    <div class='status'>
-      <p>Status: <span id="status"><span class='circle circle-red'></span>Loading...</span>
+    <div class="status">
+      <p>Status: <span id="status"><span class="circle circle-red"></span>Loading...</span>
       </p>
     </div>
 
-    <div class='info'>
-      <p>Press <kbd id='dev_tools_shortcut' class="shortcut">⌘⌥J</kbd> to open Developer Tools.</p>
-      <p id='devtools-info'></p>
+    <div class="info">
+      <p>Press <kbd id="dev_tools_shortcut" class="shortcut">⌘⌥J</kbd> to open Developer Tools.</p>
+      <p id="devtools-info"></p>
     </div>
 
     <div class="features">


### PR DESCRIPTION
This PR use quotation mark `"` to wrap HTML param value against apostrophe `'` in `src/server/assets/debugger.html`