### PR TITLE
Use module concatenation plugin and set NODE_ENV to production

### DIFF
--- a/src/utils/__tests__/__snapshots__/makeReactNativeConfig.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/makeReactNativeConfig.test.js.snap
@@ -83,9 +83,6 @@ Array [
           },
         },
       },
-      NamedModulesPlugin {
-        "options": Object {},
-      },
       SourceMapDevToolPlugin {
         "fallbackModuleFilenameTemplate": "webpack:///[resourcePath]?[hash]",
         "moduleFilenameTemplate": "webpack:///[resourcePath]",
@@ -102,6 +99,9 @@ Array [
         "multiStep": undefined,
         "options": Object {},
         "requestTimeout": 10000,
+      },
+      NamedModulesPlugin {
+        "options": Object {},
       },
     ],
     "resolve": Object {
@@ -207,9 +207,6 @@ Array [
           },
         },
       },
-      NamedModulesPlugin {
-        "options": Object {},
-      },
       SourceMapDevToolPlugin {
         "fallbackModuleFilenameTemplate": "webpack:///[resourcePath]?[hash]",
         "moduleFilenameTemplate": "webpack:///[resourcePath]",
@@ -226,6 +223,9 @@ Array [
         "multiStep": undefined,
         "options": Object {},
         "requestTimeout": 10000,
+      },
+      NamedModulesPlugin {
+        "options": Object {},
       },
     ],
     "resolve": Object {

--- a/src/utils/makeReactNativeConfig.js
+++ b/src/utils/makeReactNativeConfig.js
@@ -51,6 +51,8 @@ const getDefaultConfig = ({
   bundle,
   port,
 }): WebpackConfig => {
+  process.env.NODE_ENV = dev ? 'development' : 'production';
+
   // Getting Minor version
   const rnVersion = getRNVersion(root);
   const platformProgressBar = haulProgressBar(platform);
@@ -132,7 +134,6 @@ const getDefaultConfig = ({
         minimize: !!minify,
         debug: dev,
       }),
-      new webpack.NamedModulesPlugin(),
       /**
        * By default, sourcemaps are only generated with *.js files
        * We need to use the plugin to configure *.bundle to emit sourcemap
@@ -143,9 +144,12 @@ const getDefaultConfig = ({
       }),
     ]
       .concat(
-        process.env.NODE_ENV === 'production'
-          ? []
-          : new webpack.HotModuleReplacementPlugin()
+        dev
+          ? [
+              new webpack.HotModuleReplacementPlugin(),
+              new webpack.NamedModulesPlugin(),
+            ]
+          : new webpack.optimize.ModuleConcatenationPlugin()
       )
       .concat(
         minify
@@ -199,6 +203,9 @@ const getDefaultConfig = ({
      * Set target to webworker as it's closer to RN environment than `web`.
      */
     target: 'webworker',
+    stats: {
+      optimizationBailout: true,
+    },
   };
 };
 

--- a/src/utils/makeReactNativeConfig.js
+++ b/src/utils/makeReactNativeConfig.js
@@ -203,9 +203,6 @@ const getDefaultConfig = ({
      * Set target to webworker as it's closer to RN environment than `web`.
      */
     target: 'webworker',
-    stats: {
-      optimizationBailout: true,
-    },
   };
 };
 


### PR DESCRIPTION
#115 

Bundle size went down from 1MB+ to 621KB (65KB behind metro-bundler) for fresh RN project.

We should see more size decrease if we stop transpiling ES imports/exports to CJS.