### PR TITLE
Set proper environment for remote debugging

### DIFF
--- a/src/server/assets/debuggerWorker.js
+++ b/src/server/assets/debuggerWorker.js
@@ -11,6 +11,17 @@
 
 /* eslint-disable */
 
+/**
+ * Do not use "use strict" 
+ * (https://github.com/callstack/haul/issues/278)
+ * 
+ * The problem is that Lottie relies upon react-native-safe-module and there is the issue.
+ * React-native-safe-module is trying to "patch" the native module in order to prevent crashes
+ * but the author doesn't count on that requireNativeComponent() could return a string
+ * and that's the issue – when you try to modify string primitive property under strict
+ * mode in web worker environment you get the 'Cannot create property...' error.
+ */
+
 onmessage = (function() {
   let visibilityState;
 

--- a/src/server/assets/debuggerWorker.js
+++ b/src/server/assets/debuggerWorker.js
@@ -12,14 +12,14 @@
 /* eslint-disable */
 
 /**
- * Do not use "use strict" 
- * (https://github.com/callstack/haul/issues/278)
+ * IMPORTANT: Do not add "use strict"
+ * https://github.com/callstack/haul/issues/278
  * 
- * The problem is that Lottie relies upon react-native-safe-module and there is the issue.
- * React-native-safe-module is trying to "patch" the native module in order to prevent crashes
- * but the author doesn't count on that requireNativeComponent() could return a string
- * and that's the issue – when you try to modify string primitive property under strict
- * mode in web worker environment you get the 'Cannot create property...' error.
+ * Some libraries like react-native-safe-module try to patch native modules to mock them
+ * and prevent crashes, but don't account for the case when `requireNativeComponent` returns
+ * a string. In strict mode, trying to modify properties of the string primitive throws an
+ * error - "Cannot create property...". This breaks some modules like Lottie which use
+ * react-native-safe-module
  */
 
 onmessage = (function() {

--- a/src/server/assets/debuggerWorker.js
+++ b/src/server/assets/debuggerWorker.js
@@ -11,8 +11,6 @@
 
 /* eslint-disable */
 
-'use strict';
-
 onmessage = (function() {
   let visibilityState;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4401,7 +4401,7 @@ sax@^1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 


### PR DESCRIPTION
I've recently (#278) run into troubles with Haul and [Lottie](https://github.com/airbnb/lottie-react-native).

The problem is that Lottie relies upon [react-native-safe-module](https://github.com/lelandrichardson/react-native-safe-module) and there is the issue. React-native-safe-module is trying to ["patch" the native module in order to prevent crashes](https://github.com/lelandrichardson/react-native-safe-module/blob/master/src/NativeSafeComponent.js#L109) but the author doesn't count on that [requireNativeComponent() could return a string](https://github.com/facebook/react-native/blob/master/Libraries/ReactNative/requireNativeComponent.js#L57) and that's the issue – when you try to modify `string primitive` property under strict mode in web worker environment you get the `Cannot create property...` error.

I'm proposing hotfix to get the same behavior like in Metro Bundler.

close #278 
