### PR TITLE
Compact with third party npm tool like cnpm

### DIFF
--- a/src/utils/makeReactNativeConfig.js
+++ b/src/utils/makeReactNativeConfig.js
@@ -71,7 +71,7 @@ const getDefaultConfig = ({
         { parser: { requireEnsure: false } },
         {
           test: /\.js$/,
-          exclude: /node_modules\/(?!react|@expo|pretty-format|haul)/,
+          exclude: /node_modules\/(?!_*(react|@expo|pretty-format|haul))/,
           use: [
             {
               loader: require.resolve('thread-loader'),


### PR DESCRIPTION
Compact with third party npm tool like cnpm/npminstall, cause they use symbliclink to increase install speed, the real path of haul is `_haul-dog@1.0.0-beta.10@haul` is not match the regex statement.