### PR TITLE
fix(hmr): makeHot in production mode

### DIFF
--- a/src/hot/client/index.js
+++ b/src/hot/client/index.js
@@ -14,7 +14,12 @@
 
 if (!module.hot || process.env.NODE_ENV === 'production') {
   module.exports = {
-    makeHot() {},
+    makeHot(rootFactory: Function) {
+      /**
+      * Return the original rootFactory and be quiet.
+      */
+      return rootFactory;
+    },
     redraw() {},
     tryUpdateSelf() {},
     callOnce(callback: Function) {


### PR DESCRIPTION
`makeHot` should behave correctly and should return original `rootFactory` not `undefined` otherwise the apps in production mode will get broken. 🙏 