### PR TITLE
[WIP] Use node workers to generate bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "image-size": "^0.5.1",
     "inquirer": "^3.0.6",
     "loader-utils": "^1.1.0",
+    "memory-fs": "^0.4.1",
     "minimist": "^1.2.0",
     "morgan": "^1.8.1",
     "multi-progress": "^2.0.0",
@@ -69,7 +70,8 @@
     "webpack": "^3.6.0",
     "webpack-dev-middleware": "^1.12.0",
     "webpack-hot-middleware": "^2.19.1",
-    "ws": "^2.2.2"
+    "ws": "^2.2.2",
+    "xpipe": "^1.0.5"
   },
   "devDependencies": {
     "all-contributors-cli": "^4.5.1",

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -6,7 +6,6 @@
  */
 import type { Command } from '../types';
 
-const webpack = require('webpack');
 const path = require('path');
 const clear = require('clear');
 const inquirer = require('inquirer');
@@ -17,8 +16,6 @@ const messages = require('../messages');
 const exec = require('../utils/exec');
 const getWebpackConfig = require('../utils/getWebpackConfig');
 const { isPortTaken, killProcess } = require('../utils/haulPortHandler');
-
-const makeReactNativeConfig = require('../utils/makeReactNativeConfig');
 
 /**
  * Starts development server
@@ -46,22 +43,15 @@ async function start(opts: *) {
 
   const directory = process.cwd();
   const configPath = getWebpackConfig(directory, opts.config);
+  const configOptions = {
+    root: directory,
+    dev: opts.dev,
+    minify: opts.minify,
+    port: opts.port,
+  };
 
-  // eslint-disable-next-line prefer-const
-  let [config, platforms] = makeReactNativeConfig(
-    // $FlowFixMe: Dynamic require
-    require(configPath),
-    {
-      root: directory,
-      dev: opts.dev,
-      minify: opts.minify,
-      port: opts.port,
-    }
-  );
-
-  if (opts.platform !== 'all' && platforms.includes(opts.platform)) {
-    config = config[platforms.indexOf(opts.platform)];
-  }
+  /*
+  ** Add this to android build in middleware
 
   // Run `adb reverse` on Android
   if (opts.platform === 'android') {
@@ -95,11 +85,14 @@ async function start(opts: *) {
       port: opts.port,
     })
   );
-
-  const compiler = webpack(config);
+*/
+  logger.done(`Haul ready. Send requests to ${configOptions.port}`);
 
   createServer(
-    compiler,
+    {
+      configPath,
+      configOptions,
+    }, // passes path to config now
     didHaveIssues => {
       clear();
       if (didHaveIssues) {
@@ -168,26 +161,6 @@ module.exports = ({
         {
           value: false,
           description: 'Disables minification for the bundle',
-        },
-      ],
-    },
-    {
-      name: 'platform',
-      description: 'Platform to bundle for',
-      example: 'haul start --platform ios',
-      required: true,
-      choices: [
-        {
-          value: 'ios',
-          description: 'Serves iOS bundle',
-        },
-        {
-          value: 'android',
-          description: 'Serves Android bundle',
-        },
-        {
-          value: 'all',
-          description: 'Serves both platforms',
         },
       ],
     },

--- a/src/server/middleware/haulWebpackMiddleware/index.js
+++ b/src/server/middleware/haulWebpackMiddleware/index.js
@@ -1,0 +1,185 @@
+/**
+ * Copyright 2017-present, Callstack.
+ * All rights reserved.
+ * 
+ * @flow
+ */
+/* eslint-disable consistent-return */
+
+const net = require('net');
+const xpipe = require('xpipe');
+
+const createFork = require('./utils/createFork');
+const getFileFromPath = require('./utils/getFileFromPath');
+const { parentEv, forkEv } = require('./utils/eventNames');
+const RequestQueue = require('./utils/requestQueue');
+
+type ConfigOptionsType = {
+  root: string,
+  dev: boolean,
+  minify: boolean,
+  port: number,
+  platform: string,
+};
+
+type MiddlewareOptions = {
+  configPath: string,
+  configOptions: ConfigOptionsType,
+};
+
+/**
+ * Gets proper IPC socket name, platform specific
+ * @param {string} plat 
+ */
+const getSocket = plat => xpipe.eq(`/tmp/HAUL_SOCKET_${plat}_.socket`);
+
+/**
+ * Kills all forks and closes all connections
+ * @param {string} err 
+ */
+const closeAllConnections = err => {
+  err && console.log('Exiting with error:', err);
+  Object.keys(FORKS).forEach(plat => FORKS[plat].kill());
+  Object.keys(BUNDLE_SERVERS).forEach(plat => BUNDLE_SERVERS[plat].close());
+  process.exit(0);
+};
+
+const FORKS = {};
+const LISTENERS = {};
+const BUNDLE_SERVERS = {};
+
+const Queue = new RequestQueue();
+
+/**
+ * Throws error, saying which function failed
+ * @param {string} funcName 
+ */
+const reportError = funcName => {
+  closeAllConnections();
+  throw new Error(
+    `Middleware: No platform, ID or event to sendMessage. | ${funcName}`
+  );
+};
+
+/**
+ * on bundleSuccess, sends 
+ * @param {string} platform 
+ * @param {string} socket 
+ */
+const handleBundleSending = (platform, socket) => {
+  BUNDLE_SERVERS[platform] = net
+    .createServer({ allowHalfOpen: true }, connection => {
+      let bundle = '';
+
+      connection.setEncoding('utf-8');
+      connection.on('data', chunk => {
+        bundle += chunk;
+      });
+      connection.on('end', () => {
+        LISTENERS[platform].forEach(response => {
+          if (!response) return;
+          response.writeHead(200, { 'Content-Type': 'application/javascript' });
+          response.end(bundle);
+          return false;
+        });
+
+        connection.end();
+      });
+      connection.on('close', () => {
+        bundle = '';
+        LISTENERS[platform].length = 0;
+      });
+    })
+    .listen(socket);
+};
+
+/**
+ * Sends a message to worker, with payload
+ * @param {string} platform 
+ * @param {Object} res 
+ * @param {string} event 
+ */
+const sendMessage = (platform, res, event) => {
+  const fork = FORKS[platform];
+  const ID = Queue.addItem(res);
+
+  if (!platform || ID === undefined || !event) reportError('sendMessage');
+
+  fork.send({
+    ID,
+    event,
+  });
+};
+
+/**
+ * Handles received messages from parent
+ * @param {Object} data {ID, event, payload}
+ * @param {*} req express 'req'
+ * @param {*} res express 'res'
+ * @param {*} next express 'next'
+ */
+const receiveMessage = (data, req, res, next) => {
+  const { ID, event, payload } = data;
+
+  if (ID === undefined || !event) reportError('receiveMessage');
+
+  switch (event) {
+    case parentEv.buildFinished: {
+      Queue.getSpecific(ID); // remove item
+      break;
+    }
+    case parentEv.buildFailed: {
+      const response = Queue.getSpecific(ID);
+      response.end('BUNDLE FAILED');
+      break;
+    }
+    case parentEv.errorMessaging: {
+      closeAllConnections();
+      throw new Error(`BAD COMMUNICATIONS: ${payload}`);
+    }
+
+    default: {
+      console.log('Uhandled Event', event);
+      next();
+    }
+  }
+};
+
+module.exports = function haulMiddlewareFactory(options: MiddlewareOptions) {
+  return function webpackHaulMiddleware(req, res, next) {
+    const { platform } = req.query;
+    const fileName = getFileFromPath(req.path);
+
+    if (!platform || !fileName) return next();
+    const socket = getSocket(platform);
+
+    if (!FORKS[platform]) {
+      FORKS[platform] = createFork(
+        platform,
+        `index.${platform}.bundle`,
+        process.cwd(),
+        __dirname,
+        options,
+        socket
+      );
+
+      LISTENERS[platform] = [];
+      FORKS[platform].on('message', data =>
+        receiveMessage(data, req, res, next)
+      );
+      handleBundleSending(platform, socket);
+    }
+
+    // request bundle
+    LISTENERS[platform].push(res);
+    sendMessage(platform, res, forkEv.requestBuild);
+  };
+};
+
+process.on('uncaughtException', err => {
+  closeAllConnections(err);
+});
+
+process.on('SIGINT', () => {
+  closeAllConnections();
+});

--- a/src/server/middleware/haulWebpackMiddleware/utils/createFork.js
+++ b/src/server/middleware/haulWebpackMiddleware/utils/createFork.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2017-present, Callstack.
+ * All rights reserved.
+ * 
+ * @flow
+ */
+
+const spawn = require('child_process').spawn;
+const path = require('path');
+
+module.exports = function createFork(
+  platform: string,
+  fileOutput: string,
+  cwd: string,
+  middlewareDirectory: string,
+  middlewareOptions: Object,
+  socket: string
+) {
+  const webpackWorkerPath = path.resolve(
+    middlewareDirectory,
+    'webpackWorker.js'
+  );
+  const child = spawn(
+    process.execPath,
+    // ['--inspect=127.0.0.1:9225', webpackWorkerPath],
+    [webpackWorkerPath],
+    {
+      cwd,
+      env: {
+        HAUL_PLATFORM: platform,
+        HAUL_FILEOUTPUT: fileOutput,
+        HAUL_DIRECTORY: middlewareDirectory,
+        HAUL_OPTIONS: JSON.stringify(middlewareOptions),
+        HAUL_SOCKET: socket,
+      },
+      stdio: [0, 1, 2, 'ipc', 'pipe'],
+    }
+  );
+
+  child.on('error', e => {
+    console.log(`Child ${platform}: `, e.message);
+  });
+
+  return child;
+};

--- a/src/server/middleware/haulWebpackMiddleware/utils/eventNames.js
+++ b/src/server/middleware/haulWebpackMiddleware/utils/eventNames.js
@@ -1,0 +1,11 @@
+module.exports = {
+  parentEv: {
+    errorMessaging: 'PARENT_COMMUNICATION_ERROR',
+    buildFinished: 'BUILD_FINISHED',
+    buildFailed: 'BUILED_FAILED',
+  },
+  forkEv: {
+    errorMessaging: 'PARENT_COMMUNICATION_ERROR',
+    requestBuild: 'REQUEST_BUILD',
+  },
+};

--- a/src/server/middleware/haulWebpackMiddleware/utils/getConfig.js
+++ b/src/server/middleware/haulWebpackMiddleware/utils/getConfig.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2017-present, Callstack.
+ * All rights reserved.
+ * 
+ * @flow
+ */
+
+const makeReactNativeConfig = require('../../../../utils/makeReactNativeConfig');
+
+module.exports = (configPath, configOptions, platform) => {
+  const config = makeReactNativeConfig(
+    require(configPath),
+    configOptions,
+    platform
+  );
+
+  return config;
+};

--- a/src/server/middleware/haulWebpackMiddleware/utils/getFileFromPath.js
+++ b/src/server/middleware/haulWebpackMiddleware/utils/getFileFromPath.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2017-present, Callstack.
+ * All rights reserved.
+ * 
+ * @flow
+ */
+
+module.exports = function getFileFromPath(path: string) {
+  const fileRegExp = /\w+\.\w+\.bundle/i;
+
+  const match = path.match(fileRegExp);
+  if (match) {
+    return match[0];
+  }
+
+  return null;
+};

--- a/src/server/middleware/haulWebpackMiddleware/utils/requestQueue.js
+++ b/src/server/middleware/haulWebpackMiddleware/utils/requestQueue.js
@@ -1,0 +1,27 @@
+class RequestQueue {
+  constructor() {
+    this._queue = [];
+  }
+
+  // make getters modifying the ID
+
+  addItem(item) {
+    const id = this._queue.push(item);
+    return id - 1; // return the index of pushed element
+  }
+
+  getItem() {
+    return this._queue.pop();
+  }
+
+  getSpecific(ID) {
+    const [itemRemoved] = this._queue.splice(ID, 1);
+    return itemRemoved;
+  }
+
+  addSpecific(ID, item) {
+    this._queue.splice(ID, 0, item);
+  }
+}
+
+module.exports = RequestQueue;

--- a/src/server/middleware/haulWebpackMiddleware/utils/workerShared.js
+++ b/src/server/middleware/haulWebpackMiddleware/utils/workerShared.js
@@ -1,0 +1,104 @@
+/* eslint-disable no-param-reassign, no-debugger, no-empty */
+
+const path = require('path');
+
+module.exports = function Shared(context) {
+  const shared = {
+    compilerDone(stats) {
+      context.state = true;
+      context.webpackStats = stats;
+
+      if (!context.state) return;
+      const cbs = context.callbacks;
+      context.callbacks = [];
+      cbs.forEach(cb => {
+        cb(stats);
+      });
+
+      if (context.forceRebuild) {
+        context.forceRebuild = false;
+        shared.rebuild();
+      }
+    },
+
+    compilerInvalid(...args) {
+      context.state = false;
+      // resolve async
+      if (args.length === 2 && typeof args[1] === 'function') {
+        const callback = args[1];
+        callback();
+      }
+    },
+
+    ready(fn) {
+      if (context.state) {
+        return fn(context.webpackStats);
+      }
+
+      return context.callbacks.push(fn);
+    },
+
+    startWatch() {
+      const { compiler } = context;
+      context.watching = compiler.watch({}, shared.handleCompilerCb);
+    },
+
+    rebuild() {
+      if (context.state) {
+        context.state = false;
+        context.compiler.run(context.handleCompilerCb);
+      } else {
+        context.forceRebuild = true;
+      }
+    },
+
+    handleCompilerCb(err) {
+      if (err) {
+        context.onError(err);
+      }
+    },
+
+    waitUntilValid(cb = () => {}) {
+      if (context.watching) {
+        shared.ready(cb);
+        context.watching.invalidate();
+      }
+    },
+
+    invalidate(cb = () => {}) {
+      if (context.watching) {
+        shared.ready(cb);
+        context.watching.invalidate();
+      } else {
+        cb();
+      }
+    },
+
+    close(cb = () => {}) {
+      if (context.watching) {
+        context.watching.close(cb);
+      } else {
+        cb();
+      }
+    },
+
+    handleRequest(filename, requestProcess) {
+      const pathToFile = path.join(process.cwd(), filename);
+      try {
+        if (context.fs.statSync(pathToFile).isFile()) {
+          // requestProcess();
+        }
+      } catch (e) {}
+
+      shared.ready(requestProcess);
+    },
+  };
+
+  context.compiler.plugin('done', shared.compilerDone);
+  context.compiler.plugin('invalid', shared.compilerInvalid);
+  context.compiler.plugin('watch-run', shared.compilerInvalid);
+  context.compiler.plugin('run', shared.compilerInvalid);
+  shared.startWatch();
+
+  return shared;
+};

--- a/src/server/middleware/haulWebpackMiddleware/webpackWorker.js
+++ b/src/server/middleware/haulWebpackMiddleware/webpackWorker.js
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2017-present, Callstack.
+ * All rights reserved.
+ * 
+ * @flow
+ */
+/* Required modules */
+require('babel-register');
+
+const path = require('path');
+const webpack = require('webpack');
+const MemoryFileSystem = require('memory-fs');
+const net = require('net');
+
+/**
+ * Get env vars
+ */
+const {
+  HAUL_PLATFORM,
+  HAUL_OPTIONS: optionsPassed,
+  HAUL_FILEOUTPUT,
+  HAUL_DIRECTORY,
+  HAUL_SOCKET,
+} = process.env;
+
+/**
+ * Import custom modules
+ */
+const workerShared = require(path.resolve(
+  HAUL_DIRECTORY,
+  './utils/workerShared'
+));
+
+const { parentEv, forkEv } = require(path.resolve(
+  HAUL_DIRECTORY,
+  './utils/eventNames'
+));
+/**
+ * Get Webpack config
+ */
+const HAUL_OPTIONS = JSON.parse(optionsPassed);
+const { configPath, configOptions } = HAUL_OPTIONS;
+const getConfig = require(path.resolve(HAUL_DIRECTORY, './utils/getConfig'));
+const config = getConfig(configPath, configOptions, HAUL_PLATFORM);
+
+const context = {
+  webpackState: undefined,
+  fs: new MemoryFileSystem(),
+  state: false,
+  watching: undefined,
+  forceRebuild: false,
+  callbacks: [],
+  compiler: null,
+  onError: error => {
+    sendMessage(-1, parentEv.buildFailed, error);
+  },
+};
+
+/**
+ * Set compiler options, set fs to Memory
+ */
+context.compiler = webpack(config);
+context.compiler.outputFileSystem = context.fs;
+
+/**
+ * Add plugin hooks to webpack, setup callbacks etc.
+ */
+const shared = workerShared(context);
+
+/**
+ * Sends message to parent about error in message exchange
+ */
+const notifyParentMessageError = () => {
+  sendMessage(
+    -1,
+    forkEv.errorMessaging,
+    `From fork ${HAUL_PLATFORM}: No ID or event received. | sendMessage`
+  );
+};
+
+const receiveMessage = data => {
+  if (data.ID === undefined || !data.event) {
+    notifyParentMessageError();
+    return;
+  }
+  const taskID = data.ID;
+
+  switch (data.event) {
+    case forkEv.requestBuild: {
+      shared.handleRequest(HAUL_FILEOUTPUT, () => processRequest(taskID));
+      break;
+    }
+    default:
+      notifyParentMessageError();
+  }
+};
+
+const sendMessage = (ID, event, payload) => {
+  if (ID === undefined || !event) {
+    notifyParentMessageError();
+    return;
+  }
+
+  // Pipe the bundle to the parent
+  if (event === parentEv.buildFinished) {
+    const fileReadStream = context.fs.createReadStream(payload);
+    const conn = net.createConnection(HAUL_SOCKET);
+    conn.setEncoding('utf-8');
+    fileReadStream.pipe(conn);
+  }
+
+  console.log('\nFork answers:', ID, event);
+  process.send({
+    ID,
+    event,
+    payload,
+  });
+};
+
+/**
+ * Callback to `compiler.ready`, when webpack finishes bundle
+ * Todo: need to change its behaviour based on errors in compiling
+ * @param {number} ID 
+ */
+const processRequest = ID => {
+  const filePath = path.join(process.cwd(), HAUL_FILEOUTPUT);
+  sendMessage(ID, parentEv.buildFinished, filePath);
+};
+
+process.on('message', receiveMessage);

--- a/src/utils/makeReactNativeConfig.js
+++ b/src/utils/makeReactNativeConfig.js
@@ -64,7 +64,7 @@ const getDefaultConfig = ({
     ],
     devtool: bundle ? 'source-map' : 'eval-source-map',
     output: {
-      path: path.join(root, 'dist'),
+      path: path.join(root), // removed 'dist' from path
       filename: `index.${platform}.bundle`,
       publicPath: `http://localhost:${port}/`,
     },
@@ -208,28 +208,25 @@ const getDefaultConfig = ({
  */
 function makeReactNativeConfig(
   userWebpackConfig: WebpackConfigFactory,
-  options: ConfigOptions
+  options: ConfigOptions,
+  platform
 ): [Array<WebpackConfig>, typeof PLATFORMS] {
-  const configs = PLATFORMS.map(platform => {
-    const env = Object.assign({}, options, { platform });
-    const defaultWebpackConfig = getDefaultConfig(env);
+  const env = Object.assign({}, options, { platform });
+  const defaultWebpackConfig = getDefaultConfig(env);
 
-    const config = Object.assign(
-      {},
-      defaultWebpackConfig,
-      typeof userWebpackConfig === 'function'
-        ? userWebpackConfig(env, defaultWebpackConfig)
-        : userWebpackConfig
-    );
+  const config = Object.assign(
+    {},
+    defaultWebpackConfig,
+    typeof userWebpackConfig === 'function'
+      ? userWebpackConfig(env, defaultWebpackConfig)
+      : userWebpackConfig
+  );
 
-    // For simplicity, we don't require users to extend
-    // default config.entry but do it for them.
-    config.entry = defaultWebpackConfig.entry.concat(config.entry);
+  // For simplicity, we don't require users to extend
+  // default config.entry but do it for them.
+  config.entry = defaultWebpackConfig.entry.concat(config.entry);
 
-    return config;
-  });
-
-  return [configs, PLATFORMS];
+  return config;
 }
 
 module.exports = makeReactNativeConfig;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3382,7 +3382,7 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-memory-fs@^0.4.0, memory-fs@~0.4.1:
+memory-fs@^0.4.0, memory-fs@^0.4.1, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
   dependencies:
@@ -5106,6 +5106,10 @@ ws@^2.2.2:
 xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
+
+xpipe@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/xpipe/-/xpipe-1.0.5.tgz#8dd8bf45fc3f7f55f0e054b878f43a62614dafdf"
 
 xtend@^4.0.0, xtend@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
You can read my [Proposal here](https://github.com/callstack/haul/issues/287).

To-do:
- Change behaviours of current Haul commands (start, init, bundle)
    - [ ] start
    - [ ] init
    - [ ] bundle
- Fix middlewares that were dependant on webpack `compiler` (live reload, symbolicate)
     - [ ] live reload
     - [ ] symbolicate
- [ ] (Worker) handle webpack errors correctly
- (Middleware) normalize queue system
     - [ ] instead of using `LISTENERS`, use `requestQueue`
     - [ ] add `flushing` method to `requestQueue`, to remove all tasks once bundle has been sent
- [ ] Add more todos, because already forgot it
- [ ] Rebase with latest master
- [ ] Add flow
- [ ] Add tests