### PR TITLE
HMR hotfix

### DIFF
--- a/src/hot/client/hotPatch.js
+++ b/src/hot/client/hotPatch.js
@@ -34,7 +34,18 @@ if (typeof global.__REACT_HOT_LOADER__ !== 'undefined') {
     if (
       typeof type !== 'function' ||
       typeof uniqueLocalName !== 'string' ||
-      typeof fileName !== 'string'
+      typeof fileName !== 'string' ||
+      /**
+       * In case where someone extract function from a prototype 
+       * example: `const hasOwnProperty = Object.prototype.hasOwnProperty`,
+       * then hasOwnProperty is being patched by HMR
+       * Here: https://github.com/gaearon/react-hot-loader/blob/master/src/patch.dev.js#L14-L20
+       * When we get to point where we retrives keys from patched functions
+       * here: https://github.com/gaearon/react-hot-loader/blob/master/src/patch.dev.js#L43
+       * We'll be actually looping over `hasOwnPrototype`'s arities, which are `undefined`
+       * Accessing properties on `undefined` will throw an error
+       */
+      Object.prototype[uniqueLocalName]
     ) {
       return;
     }

--- a/src/hot/client/hotPatch.js
+++ b/src/hot/client/hotPatch.js
@@ -37,12 +37,12 @@ if (typeof global.__REACT_HOT_LOADER__ !== 'undefined') {
       typeof fileName !== 'string' ||
       /**
        * In case where someone extract function from a prototype 
-       * example: `const hasOwnProperty = Object.prototype.hasOwnProperty`,
-       * then hasOwnProperty is being patched by HMR
+       * example: `const hasOwnProperty = Object.prototype.hasOwnProperty` in `react-native-safe-module`,
+       * then `hasOwnProperty` will be patched by HMR
        * Here: https://github.com/gaearon/react-hot-loader/blob/master/src/patch.dev.js#L14-L20
        * When we get to point where we retrives keys from patched functions
        * here: https://github.com/gaearon/react-hot-loader/blob/master/src/patch.dev.js#L43
-       * We'll be actually looping over `hasOwnPrototype`'s arities, which are `undefined`
+       * We'll be actually looping over `hasOwnProperty`'s arities, which are `undefined`
        * Accessing properties on `undefined` will throw an error
        */
       Object.prototype[uniqueLocalName]


### PR DESCRIPTION
HMR would thrown an error when it finds registered function that is on a prototype. With this patch, we just make sanity check if function is on `Object.prototype`, if so, it's not a component.