### PR TITLE
Use local haul binary in fixture

### DIFF
--- a/fixtures/react-native-with-haul/package.json
+++ b/fixtures/react-native-with-haul/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "test": "jest",
-    "haul": "haul start"
+    "haul": "../../bin/cli.js"
   },
   "dependencies": {
     "react": "16.0.0",


### PR DESCRIPTION
This way you can easily type `yarn haul <command>` and test it. In time, it would be nice to extend this fixture/example to use some native code for example and test how we do with upgrading to next RN version with `react-native-git-upgrade`.

For manual testing purposes we can leave old fixtures, just so we're able to easily test different RN versions.