### PR TITLE
Change "haul start" to "haul" as a default npm-script

### DIFF
--- a/fixtures/react-native-clean/package.json
+++ b/fixtures/react-native-clean/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "test": "jest",
-    "haul": "haul start"
+    "haul": "haul"
   },
   "dependencies": {
     "react": "16.0.0",

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -151,7 +151,7 @@ const addToPackageScripts = async (cwd: string) => {
   const scripts = pjson.scripts || {};
 
   const haulScript = Object.keys(scripts).find(
-    name => scripts[name] === 'haul start'
+    name => scripts[name] === 'haul'
   );
 
   if (haulScript) {
@@ -183,7 +183,7 @@ const addToPackageScripts = async (cwd: string) => {
   }
 
   pjson.scripts = Object.assign({}, scripts, {
-    [scriptName]: 'haul start',
+    [scriptName]: 'haul',
   });
 
   const progress = ora(


### PR DESCRIPTION
This was bothering me since very beginning of using Haul. With `yarn` it's even unnecessary to add this, but I'm not sure if `npm` is as smart.

With `"haul": "haul"` instead of `"haul": "haul start"` inside npm-scripts, you can now invoke any haul command, not just start with some arbitrary args:

```sh
yarn haul # $ haul start
```

```sh
yarn haul start # $ haul start
```

```sh
yarn haul build --platform ios # $ haul build --platform ios
```

And so on. Also `start` is the default command, so 2 points for me.