### PR TITLE
fix(webpack): Stick with Webpack 3.8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,10 @@
     "traverse": "^0.6.6"
   },
   "lint-staged": {
-    "*.js": ["eslint --fix", "git add"]
+    "*.js": [
+      "eslint --fix",
+      "git add"
+    ]
   },
   "babel": {
     "presets": [
@@ -100,7 +103,10 @@
         }
       ]
     ],
-    "plugins": ["transform-flow-strip-types", "transform-object-rest-spread"]
+    "plugins": [
+      "transform-flow-strip-types",
+      "transform-object-rest-spread"
+    ]
   },
   "eslintConfig": {
     "extends": "callstack-io",
@@ -124,7 +130,9 @@
         "import/no-extraneous-dependencies": [
           "error",
           {
-            "devDependencies": ["**/integration_tests/**"]
+            "devDependencies": [
+              "**/integration_tests/**"
+            ]
           }
         ]
       }
@@ -132,10 +140,14 @@
   },
   "jest": {
     "setupTestFrameworkScriptFile": "<rootDir>/jest/setupTestFramework.js",
-    "testPathIgnorePatterns": ["/integration_tests/.*/__tests__"],
+    "testPathIgnorePatterns": [
+      "/integration_tests/.*/__tests__"
+    ],
     "moduleNameMapper": {
       "^jest/(.*)": "<rootDir>/jest/$1"
     },
-    "testMatch": ["**/*.test.js"]
+    "testMatch": [
+      "**/*.test.js"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "source-map": "^0.5.6",
     "strip-ansi": "^3.0.1",
     "thread-loader": "^1.1.1",
-    "webpack": "^3.6.0",
+    "webpack": "3.8.1",
     "webpack-dev-middleware": "^1.12.0",
     "webpack-hot-middleware": "^2.19.1",
     "ws": "^2.2.2"
@@ -86,10 +86,7 @@
     "traverse": "^0.6.6"
   },
   "lint-staged": {
-    "*.js": [
-      "eslint --fix",
-      "git add"
-    ]
+    "*.js": ["eslint --fix", "git add"]
   },
   "babel": {
     "presets": [
@@ -103,10 +100,7 @@
         }
       ]
     ],
-    "plugins": [
-      "transform-flow-strip-types",
-      "transform-object-rest-spread"
-    ]
+    "plugins": ["transform-flow-strip-types", "transform-object-rest-spread"]
   },
   "eslintConfig": {
     "extends": "callstack-io",
@@ -130,9 +124,7 @@
         "import/no-extraneous-dependencies": [
           "error",
           {
-            "devDependencies": [
-              "**/integration_tests/**"
-            ]
+            "devDependencies": ["**/integration_tests/**"]
           }
         ]
       }
@@ -140,14 +132,10 @@
   },
   "jest": {
     "setupTestFrameworkScriptFile": "<rootDir>/jest/setupTestFramework.js",
-    "testPathIgnorePatterns": [
-      "/integration_tests/.*/__tests__"
-    ],
+    "testPathIgnorePatterns": ["/integration_tests/.*/__tests__"],
     "moduleNameMapper": {
       "^jest/(.*)": "<rootDir>/jest/$1"
     },
-    "testMatch": [
-      "**/*.test.js"
-    ]
+    "testMatch": ["**/*.test.js"]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4984,9 +4984,9 @@ webpack-sources@^1.0.1:
     source-list-map "^2.0.0"
     source-map "~0.5.3"
 
-webpack@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.6.0.tgz#a89a929fbee205d35a4fa2cc487be9cbec8898bc"
+webpack@3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.8.1.tgz#b16968a81100abe61608b0153c9159ef8bb2bd83"
   dependencies:
     acorn "^5.0.0"
     acorn-dynamic-import "^2.0.0"


### PR DESCRIPTION
Sice Webpack 3.9.0 they introduce some changes that self is used before this as global.

This is just a walkaround for issues related to #308 *Can't find variable: self* . I need to dig more into it.

Background: https://github.com/webpack/webpack/pull/5862

P.S: Maybe we can force all the version to avoid such a bug in future? What do you think?