### PR TITLE
react-native not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ yarn haul start -- --platform ios
 Finally, reload your app to update the bundle or run your app just like you normally would:
 
 ```bash
-react-native run-ios
+yarn run ios
 ```
 
 <p align="center">


### PR DESCRIPTION
I don't have `react-native` on my path (and I do think I have most of the tools installed). yarn run ios seems to work (and that does call it underneath.

```
yarn run v1.3.2
$ react-native run-ios
```