### PR TITLE
Fix React Native 0.52+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ jsconfig.json
 
 # NodeJS
 node_modules/
+!**/__tests__/**/node_modules
 npm-debug.log
 yarn-debug.log
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,26 @@
-*~
+# OS X
 .DS_Store
 
+# Others
+*~
 *.log
-/node_modules
-integration_tests/fixtures/**/node_modules
-integration_tests/fixtures/**/.happypack
 
+# VSCode
 .vscode/
+tsconfig.json
 jsconfig.json
+
+# NodeJS
+node_modules/
+npm-debug.log
+yarn-debug.log
+
+# Webpack
+.happypack
+
+# Android/IJ
 .idea
-dist
-/coverage
+.gradle
+
+dist/
+coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@
 
 *.log
 /node_modules
-fixtures/**/node_modules
+integration_tests/fixtures/**/node_modules
+integration_tests/fixtures/**/.happypack
 
 .vscode/
 jsconfig.json

--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,6 @@ node_modules/
 npm-debug.log
 yarn-debug.log
 
-# Webpack
-.happypack
 
 # Android/IJ
 .idea

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ Haul uses a completely different architecture from React Native packager, which 
 
 We are actively working on adding support for the following:
 
+- Delta Bundles (RN 0.52+)
+
+Currently we don't support delta bundles (metro feature) (Android). To make Haul work with `RN 0.52+`, you have to disable that feature - During development, bring up Dev Menu (`cmd + m`), select `Dev Settings` and uncheck `Delta bundles`
+
 - Existing `react-native` commands
 
 The following features are **unlikely to be supported** in the future:

--- a/src/server/middleware/requestChangeMiddleware.js
+++ b/src/server/middleware/requestChangeMiddleware.js
@@ -23,10 +23,15 @@ module.exports = function requestChangeMiddleware(
       RN 0.52+ comes with experimental feature called Delta Bundles (from metro)
       So to overcome any issues with this feature, one needs to disable it DevMenu
     */
-    req.url = req.url.replace(
-      /index.(bundle|delta)/,
-      `index.${platform}.bundle`
-    );
+    if (platform === 'android' && /\.delta/.test(req.url)) {
+      res
+        .status(500)
+        .send(
+          'Currently Haul does not support Delta bundles. Please disable them in Dev Settings'
+        );
+    }
+
+    req.url = req.url.replace(/index.bundle/, `index.${platform}.bundle`);
   }
   next();
 };

--- a/src/server/middleware/requestChangeMiddleware.js
+++ b/src/server/middleware/requestChangeMiddleware.js
@@ -19,7 +19,14 @@ module.exports = function requestChangeMiddleware(
 ) {
   const { platform } = req.query;
   if (platform) {
-    req.url = req.url.replace('index.bundle', `index.${platform}.bundle`);
+    /*
+      RN 0.52+ comes with experimental feature called Delta Bundles (from metro)
+      So to overcome any issues with this feature, one needs to disable it DevMenu
+    */
+    req.url = req.url.replace(
+      /index.(bundle|delta)/,
+      `index.${platform}.bundle`
+    );
   }
   next();
 };

--- a/src/server/middleware/requestChangeMiddleware.js
+++ b/src/server/middleware/requestChangeMiddleware.js
@@ -31,7 +31,7 @@ module.exports = function requestChangeMiddleware(
         );
     }
 
-    req.url = req.url.replace(/index.bundle/, `index.${platform}.bundle`);
+    req.url = req.url.replace(/index\.bundle/, `index.${platform}.bundle`);
   }
   next();
 };


### PR DESCRIPTION
There is a new experimental feature by Metro, called Delta bundles. It's turned on by default, and currently we have no proper implementation of it yet. Need to further investigate.

Added appropriate `Limitation` entry, how to disable that feature.