### PR TITLE
Run adb command from path at first

### DIFF
--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -64,19 +64,19 @@ async function start(opts: *) {
 
   // Run `adb reverse` on Android
   if (opts.platform === 'android') {
-    const args = `reverse tcp:${opts.port} tcp:${opts.port}`;
+    const command = `adb reverse tcp:${opts.port} tcp:${opts.port}`;
 
     try {
-      await exec(`adb ${args}`);
+      await exec(command);
       logger.info(
         messages.commandSuccess({
-          command: `adb ${args}`,
+          command,
         })
       );
     } catch (error) {
       logger.warn(
         messages.commandFailed({
-          command: `adb ${args}`,
+          command,
           error,
         })
       );

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -7,7 +7,6 @@
 import type { Command } from '../types';
 
 const webpack = require('webpack');
-const path = require('path');
 const clear = require('clear');
 const inquirer = require('inquirer');
 
@@ -66,21 +65,24 @@ async function start(opts: *) {
   // Run `adb reverse` on Android
   if (opts.platform === 'android') {
     const args = `reverse tcp:${opts.port} tcp:${opts.port}`;
-    const adb = process.env.ANDROID_HOME
-      ? `${process.env.ANDROID_HOME}/platform-tools/adb`
-      : 'adb';
+    /**
+     * ADB should be taken from path (the correct setup is even in React Native documentation)
+     * 
+     * @see https://facebook.github.io/react-native/docs/getting-started.html
+     */
+    const adb = 'adb';
 
     try {
       await exec(`${adb} ${args}`);
       logger.info(
         messages.commandSuccess({
-          command: `${path.basename(adb)} ${args}`,
+          command: `${adb} ${args}`,
         })
       );
     } catch (error) {
       logger.warn(
         messages.commandFailed({
-          command: `${path.basename(adb)} ${args}`,
+          command: `${adb} ${args}`,
           error,
         })
       );

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -65,24 +65,18 @@ async function start(opts: *) {
   // Run `adb reverse` on Android
   if (opts.platform === 'android') {
     const args = `reverse tcp:${opts.port} tcp:${opts.port}`;
-    /**
-     * ADB should be taken from path (the correct setup is even in React Native documentation)
-     * 
-     * @see https://facebook.github.io/react-native/docs/getting-started.html
-     */
-    const adb = 'adb';
 
     try {
-      await exec(`${adb} ${args}`);
+      await exec(`adb ${args}`);
       logger.info(
         messages.commandSuccess({
-          command: `${adb} ${args}`,
+          command: `adb ${args}`,
         })
       );
     } catch (error) {
       logger.warn(
         messages.commandFailed({
-          command: `${adb} ${args}`,
+          command: `adb ${args}`,
           error,
         })
       );


### PR DESCRIPTION
We should keep it simple and run `adb` from a path. Assumes that user has environment setup correctly according to https://facebook.github.io/react-native/docs/getting-started.html

Fixes #331 