### PR TITLE
Add fixtures to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,7 @@
 # tests
 __tests__
 /integration_tests
+/fixtures
 
 # docs and tooling
 /docs


### PR DESCRIPTION
We shouldn't release fixtures to end users.