### PR TITLE
support bundle files without "index" in the name

### DIFF
--- a/src/utils/polyfillEnvironment.js
+++ b/src/utils/polyfillEnvironment.js
@@ -42,9 +42,15 @@ const scriptURL = require('react-native').NativeModules.SourceCode.scriptURL; //
 // or Android device it will be `localhost:<port>` but when using real iOS device
 // it will be `<ip>.xip.io:<port>`. Thus the code below ensure we connect and download
 // manifest/hot-update from a valid origin.
-const match = scriptURL && scriptURL.match(/(^.+)\/index/);
+let devServerOrigin = null;
 
-global.DEV_SERVER_ORIGIN = match ? match[1] : null;
+if (scriptURL) {
+  const [protocol, , origin] = scriptURL.split('/');
+  devServerOrigin = `${protocol}//${origin}`;
+}
+
+global.DEV_SERVER_ORIGIN = devServerOrigin;
+
 // Webpack's `publicPath` needs to be overwritten with `DEV_SERVER_ORIGIN` otherwise,
 // it would still make requests to (usually) `localhost`.
 __webpack_require__.p = `${global.DEV_SERVER_ORIGIN}/`; // eslint-disable-line no-undef


### PR DESCRIPTION
We have a project where we have more entry-points in addition to the `index.js`, but these other entry-point files don't have `index` in their name.  (If you're curious about the  use-case for this, it's because we are using [react-native-threads](https://github.com/joltup/react-native-threads).

This PR is a different strategy for finding the dev server origin without looking specifically for `index`.  I'm very open to feedback on this approach or if anyone has a better idea for going about it.