### PR TITLE
gracefully add gradle cliPath config

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -250,11 +250,11 @@ const addToGradleBuild = async (cwd: string) => {
   let project = fs.readFileSync(entry).toString();
 
   const cliString = '"node_modules/haul/bin/cli.js"';
-
   const gradleConf = `
-    project.ext.react = [
-      cliPath: ${cliString}
-    ]
+    if (!project.hasProperty('react')) {
+      project.ext.react = [:]
+    }
+    project.ext.react['cliPath'] = ${cliString}
   `;
 
   // Are we already integrated?


### PR DESCRIPTION
Fixes #376 

Instead adding a `project.ext.react` initialization with the `cliPath` for haul which could potentially clobber existing config, this initializes the `project.ext.react` config map if necessary, and then explicitly assigns the `cliPath` value. 