### PR TITLE
Read rn-cli.config.js to add additional platforms

### DIFF
--- a/src/commands/bundle.js
+++ b/src/commands/bundle.js
@@ -14,6 +14,7 @@ const { MessageError } = require('../errors');
 const messages = require('../messages');
 const { makeReactNativeConfig } = require('../utils/makeReactNativeConfig');
 const getWebpackConfig = require('../utils/getWebpackConfig');
+const { extraPlatformsDescriptions } = require('../utils/loadRnCli');
 const logger = require('../logger');
 
 /**
@@ -23,10 +24,7 @@ async function bundle(opts: *) {
   const directory = process.cwd();
   const configPath = getWebpackConfig(directory, opts.config);
 
-  const [
-    configs,
-    availablePlatforms,
-  ] = makeReactNativeConfig(
+  const [configs, availablePlatforms] = makeReactNativeConfig(
     // $FlowFixMe: Dynamic require
     require(configPath),
     {
@@ -143,6 +141,7 @@ module.exports = ({
           value: 'android',
           description: 'Builds Android bundle',
         },
+        ...extraPlatformsDescriptions(),
       ],
       example: 'haul bundle --platform ios',
     },

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -16,7 +16,7 @@ const messages = require('../messages');
 const exec = require('../utils/exec');
 const getWebpackConfig = require('../utils/getWebpackConfig');
 const { isPortTaken, killProcess } = require('../utils/haulPortHandler');
-
+const { extraPlatformsDescriptions } = require('../utils/loadRnCli');
 const { makeReactNativeConfig } = require('../utils/makeReactNativeConfig');
 
 /**
@@ -179,9 +179,10 @@ module.exports = ({
           value: 'android',
           description: 'Serves Android bundle',
         },
+        ...extraPlatformsDescriptions(),
         {
           value: 'all',
-          description: 'Serves both platforms',
+          description: 'Serves all platforms',
         },
       ],
     },

--- a/src/utils/__tests__/__mocks__/fs.js
+++ b/src/utils/__tests__/__mocks__/fs.js
@@ -1,0 +1,41 @@
+import path from 'path';
+
+const fs = jest.genMockFromModule('fs');
+
+let mockFiles = {};
+
+function __setMockFiles(newMockFiles) {
+  Object.entries(newMockFiles).forEach(([filePath, file]) => {
+    const dir = path.dirname(filePath);
+    if (!mockFiles[dir]) mockFiles[dir] = {};
+    mockFiles[dir][path.basename(filePath)] = file;
+  });
+}
+
+function __reset() {
+  mockFiles = {};
+}
+
+function readdirSync(directoryPath) {
+  return Object.keys(mockFiles[directoryPath] || {});
+}
+
+function readFileSync(filename) {
+  const dir = path.dirname(filename);
+  const basename = path.basename(filename);
+  return mockFiles[dir][basename];
+}
+
+function lstatSync(directoryPath = '') {
+  if (Object.keys(mockFiles[directoryPath] || {}).length)
+    return { isDirectory: () => true, isFile: () => false };
+  return { isDirectory: () => false, isFile: () => true };
+}
+
+fs.__setMockFiles = __setMockFiles;
+fs.__reset = __reset;
+fs.lstatSync = lstatSync;
+fs.readdirSync = readdirSync;
+fs.readFileSync = readFileSync;
+
+module.exports = fs;

--- a/src/utils/__tests__/findProvidesModule.test.js
+++ b/src/utils/__tests__/findProvidesModule.test.js
@@ -1,0 +1,51 @@
+import findProvidesModule from '../findProvidesModule';
+
+jest.mock('fs');
+
+describe('for findProvidesModule', () => {
+  afterEach(() => {
+    require('fs').__reset();
+    jest.restoreAllMocks();
+  });
+
+  describe('when there are unique modules', () => {
+    beforeEach(() => {
+      require('fs').__setMockFiles({
+        '/web/file1.web.js':
+          '/* @providesModule File1 */ console.log("file1 contents");',
+        '/web/file2.web.js':
+          '/* @providesModule File2 */ console.log("file2 contents");',
+        '/web/file3.web.js': 'console.log("file3 contents");',
+      });
+    });
+
+    test('returns a module map of haste modules', () => {
+      const directories = ['/web'];
+      const modulesMap = findProvidesModule(directories, {
+        platforms: ['web'],
+      });
+      expect(modulesMap).toEqual({ File1: '/web/file1', File2: '/web/file2' });
+    });
+  });
+
+  describe('when there are not unique modules', () => {
+    beforeEach(() => {
+      require('fs').__setMockFiles({
+        '/web/file1.web.js':
+          '/* @providesModule File1 */ console.log("file1 contents");',
+        '/web/file2.web.js':
+          '/* @providesModule File2 */ console.log("file2 contents");',
+        '/web/file3.web.js':
+          '/* @providesModule File2 */ console.log("file3 contents");',
+      });
+    });
+
+    test('returns a module map of haste modules with the first found entry', () => {
+      const directories = ['/web'];
+      const modulesMap = findProvidesModule(directories, {
+        platforms: ['web'],
+      });
+      expect(modulesMap).toEqual({ File1: '/web/file1', File2: '/web/file2' });
+    });
+  });
+});

--- a/src/utils/__tests__/loadRnCli.test.js
+++ b/src/utils/__tests__/loadRnCli.test.js
@@ -1,0 +1,63 @@
+import subject from '../loadRnCli';
+
+describe('for loadRnCli', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('extraPlatforms', () => {
+    test('returns additional platforms from rn-cli.config.js', () => {
+      jest.spyOn(subject, 'loadRnCli').mockImplementation(() => ({
+        getPlatforms: () => ['test'],
+      }));
+
+      expect(subject.extraPlatforms()).toEqual(['test']);
+    });
+
+    test('returns an empty array when getPlatforms is not a function', () => {
+      jest.spyOn(subject, 'loadRnCli').mockImplementation(() => ({}));
+
+      expect(subject.extraPlatforms()).toEqual([]);
+    });
+  });
+
+  describe('extraPlatformsDescriptions', () => {
+    test('returns additional platforms from rn-cli.config.js', () => {
+      jest.spyOn(subject, 'loadRnCli').mockImplementation(() => ({
+        getPlatforms: () => ['test'],
+      }));
+
+      expect(subject.extraPlatformsDescriptions()).toEqual([
+        { description: 'Builds test bundle', value: 'test' },
+      ]);
+    });
+
+    test('returns an empty array when getPlatforms is not a function', () => {
+      jest.spyOn(subject, 'loadRnCli').mockImplementation(() => ({}));
+
+      expect(subject.extraPlatformsDescriptions()).toEqual([]);
+    });
+  });
+
+  describe('extraProvidesModuleNodeModules', () => {
+    test('returns additional node modules from rn-cli.config.js in reverse order', () => {
+      jest.spyOn(subject, 'loadRnCli').mockImplementation(() => ({
+        getProvidesModuleNodeModules: () => [
+          'react-native',
+          'react-native-test',
+        ],
+      }));
+
+      expect(subject.extraProvidesModuleNodeModules()).toEqual([
+        'react-native-test',
+        'react-native',
+      ]);
+    });
+
+    test('returns an empty array when getProvidesModuleNodeModules is not a function', () => {
+      jest.spyOn(subject, 'loadRnCli').mockImplementation(() => ({}));
+
+      expect(subject.extraProvidesModuleNodeModules()).toEqual([]);
+    });
+  });
+});

--- a/src/utils/findProvidesModule.js
+++ b/src/utils/findProvidesModule.js
@@ -6,6 +6,7 @@
  */
 const fs = require('fs');
 const path = require('path');
+const { extraPlatforms } = require('./loadRnCli');
 
 const defaultOpts = {
   // An array of folders to ignore when building map of modules
@@ -20,7 +21,7 @@ const defaultOpts = {
   ],
   // An array of platform extensions to look for when locating
   // modules
-  platforms: ['ios', 'android', 'native', 'web'],
+  platforms: ['ios', 'android', 'native', 'web', ...extraPlatforms()],
 };
 
 /**
@@ -82,12 +83,9 @@ function findProvidesModule(directories, opts = {}) {
         return;
       }
 
-      // Throw when duplicated modules are provided from a different
-      // fileName
-      if (modulesMap[moduleName] && modulesMap[moduleName] !== fileName) {
-        throw new Error('Duplicate haste module found');
+      if (!modulesMap[moduleName] || modulesMap[moduleName] === fileName) {
+        modulesMap[moduleName] = fileName;
       }
-      modulesMap[moduleName] = fileName;
     }
   };
 

--- a/src/utils/loadRnCli.js
+++ b/src/utils/loadRnCli.js
@@ -1,0 +1,39 @@
+const path = require('path');
+
+const LoadRnCli = {
+  extraPlatforms(directory) {
+    const { getPlatforms } = LoadRnCli.loadRnCli(directory);
+    if (typeof getPlatforms === 'function') {
+      return getPlatforms();
+    }
+    return [];
+  },
+
+  extraPlatformsDescriptions(directory) {
+    return LoadRnCli.extraPlatforms(directory).map(platform => {
+      return {
+        value: platform,
+        description: `Builds ${platform} bundle`,
+      };
+    });
+  },
+
+  extraProvidesModuleNodeModules(directory) {
+    const { getProvidesModuleNodeModules } = LoadRnCli.loadRnCli(directory);
+    if (typeof getProvidesModuleNodeModules === 'function') {
+      return [...getProvidesModuleNodeModules()].reverse();
+    }
+    return [];
+  },
+
+  loadRnCli(directory = process.cwd()) {
+    try {
+      const rnCliConfigPath = path.resolve(directory, 'rn-cli.config.js');
+      return require(rnCliConfigPath);
+    } catch (error) {
+      return {};
+    }
+  },
+};
+
+module.exports = LoadRnCli;

--- a/src/utils/makeReactNativeConfig.js
+++ b/src/utils/makeReactNativeConfig.js
@@ -14,8 +14,12 @@ const AssetResolver = require('../resolvers/AssetResolver');
 const HasteResolver = require('../resolvers/HasteResolver');
 const moduleResolve = require('../utils/resolveModule');
 const getBabelConfig = require('./getBabelConfig');
+const {
+  extraPlatforms,
+  extraProvidesModuleNodeModules,
+} = require('./loadRnCli');
 
-const PLATFORMS = ['ios', 'android'];
+const PLATFORMS = ['ios', 'android', ...extraPlatforms()];
 
 type ConfigOptions = {
   root: string,
@@ -155,8 +159,8 @@ const getDefaultConfig = ({
               new webpack.optimize.UglifyJsPlugin({
                 /**
                  * By default, uglify only minifies *.js files
-                 * We need to use the plugin to configure *.bundle (Android, iOS - development) 
-                 * and *.jsbundle (iOS - production) to get minified. 
+                 * We need to use the plugin to configure *.bundle (Android, iOS - development)
+                 * and *.jsbundle (iOS - production) to get minified.
                  * Also disable IE8 support as we don't need it.
                  */
                 test: /\.(js|(js)?bundle)($|\?)/i,
@@ -193,7 +197,13 @@ const getDefaultConfig = ({
          * We don't support it, but need to provide a compatibility layer
          */
         new HasteResolver({
-          directories: [moduleResolve(root, 'react-native')],
+          directories: extraPlatforms().includes(platform)
+            ? [...extraProvidesModuleNodeModules(), 'react-native'].map(
+                provider => {
+                  return moduleResolve(root, provider);
+                }
+              )
+            : [moduleResolve(root, 'react-native')],
         }),
         /**
          * This is required by asset loader to resolve extra scales


### PR DESCRIPTION
When the rn-cli.config.js file is detected add the platforms specified to haul. 