### PR TITLE
remove haste references from polyfillEnvironment

### DIFF
--- a/src/utils/polyfillEnvironment.js
+++ b/src/utils/polyfillEnvironment.js
@@ -6,6 +6,7 @@
  *
  * This file is loaded as a part of user bundle
  */
+import { NativeModules } from 'react-native';
 
 /* eslint-disable import/no-extraneous-dependencies */
 require('../../vendor/polyfills/console.js')(global);
@@ -32,7 +33,7 @@ if (!global.self) {
   global.self = global; /* eslint-disable-line */
 }
 
-require('InitializeCore'); // eslint-disable-line import/no-unresolved
+require('react-native/Libraries/Core/InitializeCore');
 
 require('../hot/client/importScriptsPolyfill');
 
@@ -53,7 +54,7 @@ if (process.env.NODE_ENV !== 'production') {
     // from URL from which the bundle was loaded. When using iOS simulator/Android emulator
     // or Android device it will be `localhost:<port>` but when using real iOS device
     // it will be `<ip>.xip.io:<port>`.
-    const { scriptURL } = require('react-native').NativeModules.SourceCode; // eslint-disable-line import/no-unresolved
+    const { scriptURL } = NativeModules.SourceCode;
     if (scriptURL) {
       [protocol, , origin] = scriptURL.split('/');
     }


### PR DESCRIPTION
Hi,

This is part of a greater change to get tree shaking to work with react-native. In order to use webpack's tree shaking I need to remove the use of haste. I'm planning to start a discussion upstream in react-native but I also wanted to make the haste references that haul uses in polyfillEnvironment.

I'm planning to use this fork to show how someone could use haul and webpack with react-native to get tree shaking to work on their react-native apps. In my example on an android test project is was able to shrink the bundle size from 500k with metro to 260k using haul.

I'm also open to writing a babel-plugin to de-haste the source but I thought I would try to make these small changes in haul.