### PR TITLE
Fixing Haste module resolution when react-native is symlinked

### DIFF
--- a/src/utils/resolveModule.js
+++ b/src/utils/resolveModule.js
@@ -5,16 +5,16 @@
  * @flow
  */
 
-const resolver = require('resolve');
 const path = require('path');
-
+const fs = require('fs');
+const resolver = require('resolve');
 /**
-* Resolves the path to a given module
+* Resolves the real path to a given module
 * We point to 'package.json', then remove it to receive a path to the directory itself
 */
 
 module.exports = (root: string, name: string) => {
   const filePath = resolver.sync(`${name}/package.json`, { basedir: root });
-
-  return path.dirname(filePath);
+  const realPath = fs.realpathSync(filePath);
+  return path.dirname(realPath);
 };


### PR DESCRIPTION
Haste does not play nice with symlinks, and when react-native is symlinked, react native fails to resolve modules that aren't imported via relative paths. This resolves the sym link issue by resolving a real path for react-native, letting Haste do its thing.

As far as I can tell, this resolveModule.js is only referenced when building the react native webpack config, and is only used for react-native. Please let me know if there is a better place to put this.