### PR TITLE
fix: remove escape characters around $@

### DIFF
--- a/src/utils/haul-integrate.sh
+++ b/src/utils/haul-integrate.sh
@@ -15,5 +15,5 @@ SRC="$(cd "${SCRIPT_SRC}" && pwd)"
 sed -i -e 's|$REACT_NATIVE_DIR/local-cli/cli.js|./node_modules/.bin/haul|' ${SRC}/react-native-xcode.sh
 
 # Replace `react-native start` in `packager.sh`
-PACKAGER_CONTENT="cd \"$THIS_DIR/../../../../\" && node \"./node_modules/.bin/haul\" start --platform ios \"\$@\""
+PACKAGER_CONTENT="cd \"$THIS_DIR/../../../../\" && node \"./node_modules/.bin/haul\" start --platform ios $@"
 echo "$PACKAGER_CONTENT" > ${SRC}/packager.sh


### PR DESCRIPTION
Remove escape characters around $@ to allow additional parameters to be used within the haul integrate script