### PR TITLE
Explicitly transpile `metro` dependency (fixes #400)

### DIFF
--- a/src/utils/__tests__/__snapshots__/makeReactNativeConfig.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/makeReactNativeConfig.test.js.snap
@@ -17,7 +17,7 @@ Array [
           },
         },
         Object {
-          "exclude": /node_modules\\\\/\\(\\?!react\\|@expo\\|pretty-format\\|haul\\)/,
+          "exclude": /node_modules\\\\/\\(\\?!react\\|@expo\\|pretty-format\\|haul\\|metro\\)/,
           "test": /\\\\\\.js\\$/,
           "use": Array [
             Object {
@@ -341,7 +341,7 @@ if (!Array.prototype.includes) {
           },
         },
         Object {
-          "exclude": /node_modules\\\\/\\(\\?!react\\|@expo\\|pretty-format\\|haul\\)/,
+          "exclude": /node_modules\\\\/\\(\\?!react\\|@expo\\|pretty-format\\|haul\\|metro\\)/,
           "test": /\\\\\\.js\\$/,
           "use": Array [
             Object {

--- a/src/utils/makeReactNativeConfig.js
+++ b/src/utils/makeReactNativeConfig.js
@@ -75,7 +75,7 @@ const getDefaultConfig = ({
         { parser: { requireEnsure: false } },
         {
           test: /\.js$/,
-          exclude: /node_modules\/(?!react|@expo|pretty-format|haul)/,
+          exclude: /node_modules\/(?!react|@expo|pretty-format|haul|metro)/,
           use: [
             {
               loader: require.resolve('babel-loader'),


### PR DESCRIPTION
Since React Native 0.54 `metro/src/lib/bundle-modules/MetroClient.js` file is being included into bundle, and it contains a not traspiled `const` which makes Android sad.