### PR TITLE
Fix/deprecated loader context

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,14 +25,14 @@
   "license": "MIT",
   "bugs": "https://github.com/callstack-io/haul/issues",
   "peerDependencies": {
-    "babel-preset-react-native": "^2.0.0",
+    "babel-preset-react-native": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "react": "*",
     "react-native": "*"
   },
   "dependencies": {
     "@zamotany/react-proxy": "3.0.0-alpha.4",
     "babel-core": "^6.24.0",
-    "babel-loader": "^7.1.2",
+    "babel-loader": "^7.1.4",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-env": "^1.2.2",
@@ -68,7 +68,7 @@
     "semver": "^5.5.0",
     "source-map": "^0.5.6",
     "strip-ansi": "^3.0.1",
-    "thread-loader": "^1.1.1",
+    "thread-loader": "^1.1.5",
     "webpack": "^4.1.0",
     "webpack-dev-middleware": "^1.12.0",
     "webpack-hot-middleware": "^2.19.1",

--- a/src/loaders/assetLoader.js
+++ b/src/loaders/assetLoader.js
@@ -27,7 +27,7 @@ module.exports = async function assetLoader() {
   const callback = this.async();
 
   const query = utils.getOptions(this) || {};
-  const options = this.options[query.config] || {};
+  const options = (this.options || {})[query.config] || {};
   const config: Config = Object.assign(
     {},
     { platform: 'ios', root: process.cwd() },

--- a/yarn.lock
+++ b/yarn.lock
@@ -644,9 +644,9 @@ babel-jest@test:
     babel-plugin-istanbul "^4.0.0"
     babel-preset-jest "21.0.0-alpha.1"
 
-babel-loader@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.1.2.tgz#f6cbe122710f1aa2af4d881c6d5b54358ca24126"
+babel-loader@^7.1.4:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-7.1.4.tgz#e3463938bd4e6d55d1c174c5485d406a188ed015"
   dependencies:
     find-cache-dir "^1.0.0"
     loader-utils "^1.0.2"
@@ -6865,9 +6865,9 @@ text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
-thread-loader@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/thread-loader/-/thread-loader-1.1.1.tgz#a351bd9d12978f42b82aab74f76e896eed0a2ba6"
+thread-loader@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/thread-loader/-/thread-loader-1.1.5.tgz#7f9d6701f773734fff1832586779021ab8571917"
   dependencies:
     async "^2.3.0"
     loader-runner "^2.3.0"


### PR DESCRIPTION
Two things:

 * Fix a crash with webpack 4.5.0 due to the use of the previously deprecated and noe presumeably removed `this.options` loader context variable
 * Minor upgrades to some dependencies to prevent peer dependency warnings when using webpack 4