### PR TITLE
Inform user that compiler uses ZERO-CONFIGURATION 🚀mode

### DIFF
--- a/src/utils/getConfig.js
+++ b/src/utils/getConfig.js
@@ -7,15 +7,15 @@
 import type { Platform, Logger } from '../types';
 
 const path = require('path');
+const loggerUtil = require('../logger');
 const { createWebpackConfig } = require('../index');
-
 const { makeReactNativeConfig } = require('./makeReactNativeConfig');
 
 module.exports = function getConfig(
   configPath: ?string,
   configOptions: any,
   platform: Platform,
-  logger?: Logger
+  logger?: Logger = loggerUtil
 ) {
   let config;
 
@@ -37,6 +37,9 @@ module.exports = function getConfig(
     config = {
       webpack: createWebpackConfig({ entry }),
     };
+    logger.info(
+      `We're not able to locate haul.config.js.\nTrying to serve app with the default configuration from ${entry}`
+    );
   } else {
     // $FlowFixMe
     config = require(configPath);

--- a/src/utils/getConfig.js
+++ b/src/utils/getConfig.js
@@ -38,7 +38,7 @@ module.exports = function getConfig(
       webpack: createWebpackConfig({ entry }),
     };
     logger.info(
-      `Haul was not able to locate haul.config.js.\nTrying to serve app with the default configuration from ${entry}`
+      `Couldn't find "haul.config.js". Using default configuration.\nFound entry file at ${entry}.`
     );
   } else {
     // $FlowFixMe

--- a/src/utils/getConfig.js
+++ b/src/utils/getConfig.js
@@ -38,7 +38,7 @@ module.exports = function getConfig(
       webpack: createWebpackConfig({ entry }),
     };
     logger.info(
-      `We're not able to locate haul.config.js.\nTrying to serve app with the default configuration from ${entry}`
+      `Haul was not able to locate haul.config.js.\nTrying to serve app with the default configuration from ${entry}`
     );
   } else {
     // $FlowFixMe


### PR DESCRIPTION
It's nice to inform a user that Haul is trying to run in "default" mode. It could help to avoid confusion in case that user misspells the config file.

Feel free to rephrase it.

<img width="682" alt="screen shot 2018-04-22 at 10 58 55" src="https://user-images.githubusercontent.com/8135252/39093252-81e79c80-461c-11e8-8a78-27c3a6c512d6.png">
