### PR TITLE
Seek for the deprecated config file 🔎

### DIFF
--- a/src/commands/bundle.js
+++ b/src/commands/bundle.js
@@ -9,7 +9,7 @@ import type { Command } from '../types';
 const path = require('path');
 const webpack = require('webpack');
 const clear = require('clear');
-const { DEFAULT_CONFIG_FILE_PATH } = require('../constants');
+const { DEFAULT_CONFIG_FILENAME } = require('../constants');
 
 const { MessageError } = require('../errors');
 const messages = require('../messages');
@@ -149,8 +149,8 @@ module.exports = ({
     },
     {
       name: 'config',
-      description: `Path to config file, eg. ${DEFAULT_CONFIG_FILE_PATH}`,
-      default: DEFAULT_CONFIG_FILE_PATH,
+      description: `Path to config file, eg. ${DEFAULT_CONFIG_FILENAME}`,
+      default: DEFAULT_CONFIG_FILENAME,
     },
   ],
 }: Command);

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -12,7 +12,7 @@ const logger = require('../logger');
 const createServer = require('../server');
 const getWebpackConfigPath = require('../utils/getWebpackConfigPath');
 const { isPortTaken, killProcess } = require('../utils/haulPortHandler');
-const { DEFAULT_CONFIG_FILE_PATH, DEFAULT_PORT } = require('../constants');
+const { DEFAULT_CONFIG_FILENAME, DEFAULT_PORT } = require('../constants');
 
 /**
  * Starts development server
@@ -99,8 +99,8 @@ module.exports = ({
     },
     {
       name: 'config',
-      description: `Path to config file, eg. ${DEFAULT_CONFIG_FILE_PATH}`,
-      default: DEFAULT_CONFIG_FILE_PATH,
+      description: `Path to config file, eg. ${DEFAULT_CONFIG_FILENAME}`,
+      default: DEFAULT_CONFIG_FILENAME,
     },
   ],
 }: Command);

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,5 @@
 module.exports = {
+  DEPRECATED_DEFAULT_CONFIG_FILE_PATH: 'webpack.haul.js',
   DEFAULT_CONFIG_FILE_PATH: 'haul.config.js',
   DEFAULT_PORT: 8081,
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,5 @@
 module.exports = {
-  DEPRECATED_DEFAULT_CONFIG_FILE_PATH: 'webpack.haul.js',
-  DEFAULT_CONFIG_FILE_PATH: 'haul.config.js',
+  DEPRECATED_DEFAULT_CONFIG_FILENAME: 'webpack.haul.js',
+  DEFAULT_CONFIG_FILENAME: 'haul.config.js',
   DEFAULT_PORT: 8081,
 };

--- a/src/messages/webpackConfigNotFound.js
+++ b/src/messages/webpackConfigNotFound.js
@@ -7,7 +7,7 @@
 const dedent = require('dedent');
 const chalk = require('chalk');
 const path = require('path');
-const { DEFAULT_CONFIG_FILE_PATH } = require('../constants');
+const { DEFAULT_CONFIG_FILENAME } = require('../constants');
 
 module.exports = (directory: string) => dedent`
    Couldn't find configuration file ${chalk.bold(directory)}
@@ -17,6 +17,6 @@ module.exports = (directory: string) => dedent`
    • You have a ${chalk.bold(path.basename(directory))} file
 
    Run ${chalk.bold('haul init')} to automatically generate a ${chalk.bold(
-  DEFAULT_CONFIG_FILE_PATH
+  DEFAULT_CONFIG_FILENAME
 )} file
 `;

--- a/src/utils/getConfig.js
+++ b/src/utils/getConfig.js
@@ -20,7 +20,7 @@ module.exports = function getConfig(
   let config;
 
   /**
-   * When it doesn't have DEFAULT_CONFIG_FILE_PATH and it's not specified another file
+   * When it doesn't have DEFAULT_CONFIG_FILENAME and it's not specified another file
    * we will use default configuration based on main file from package.json
    */
   if (configPath === null) {

--- a/src/utils/getWebpackConfigPath.js
+++ b/src/utils/getWebpackConfigPath.js
@@ -8,27 +8,48 @@ const path = require('path');
 const fs = require('fs');
 const { MessageError } = require('../errors');
 const messages = require('../messages');
-const { DEFAULT_CONFIG_FILE_PATH } = require('../constants');
+const {
+  DEFAULT_CONFIG_FILE_PATH,
+  DEPRECATED_DEFAULT_CONFIG_FILE_PATH,
+} = require('../constants');
 
-module.exports = function getWebpackConfigPath(cwd: string, config: string) {
-  let configPath;
+module.exports = function getWebpackConfigPath(
+  cwd: string,
+  config: string = DEFAULT_CONFIG_FILE_PATH
+) {
+  const getConfigPath = file =>
+    path.isAbsolute(file) ? file : path.join(cwd, file);
 
-  if (path.isAbsolute(config)) {
-    configPath = config;
-  } else {
-    configPath = path.join(cwd, config);
-  }
-
+  let configPath = getConfigPath(config);
   /**
    * If the file doesn't exist let's check if doesn't exist the DEFAULT_CONFIG_FILE_PATH
    * if so we want to fallback to default configuration (null)
    * if doesn't exist file specified by user we should inform about it
    */
   if (!fs.existsSync(configPath)) {
-    if (config !== DEFAULT_CONFIG_FILE_PATH) {
+    if (
+      ![DEFAULT_CONFIG_FILE_PATH, DEPRECATED_DEFAULT_CONFIG_FILE_PATH].includes(
+        config
+      )
+    ) {
       throw new MessageError(messages.webpackConfigNotFound(configPath));
     }
 
+    /**
+     * For some time we want to check also this:
+     * If we wasn't able to locate DEFAULT_CONFIG_FILE_PATH maybe we could be successful
+     * in search to DEPRECATED_DEFAULT_CONFIG_FILE_PATH, let's return it if we have found it.
+     *
+     * Once we are about to remove this we can refactor L13 back to: `if (config !== DEFAULT_CONFIG_FILE_PATH)`
+     * @deprecated
+     */
+    if (fs.existsSync(getConfigPath(DEPRECATED_DEFAULT_CONFIG_FILE_PATH))) {
+      return getConfigPath(DEPRECATED_DEFAULT_CONFIG_FILE_PATH);
+    }
+
+    /**
+     * Null is flag for 'zero-config' mode
+     */
     configPath = null;
   }
 

--- a/src/utils/getWebpackConfigPath.js
+++ b/src/utils/getWebpackConfigPath.js
@@ -9,26 +9,26 @@ const fs = require('fs');
 const { MessageError } = require('../errors');
 const messages = require('../messages');
 const {
-  DEFAULT_CONFIG_FILE_PATH,
-  DEPRECATED_DEFAULT_CONFIG_FILE_PATH,
+  DEFAULT_CONFIG_FILENAME,
+  DEPRECATED_DEFAULT_CONFIG_FILENAME,
 } = require('../constants');
 
 module.exports = function getWebpackConfigPath(
   cwd: string,
-  config: string = DEFAULT_CONFIG_FILE_PATH
+  config: string = DEFAULT_CONFIG_FILENAME
 ) {
   const getConfigPath = file =>
     path.isAbsolute(file) ? file : path.join(cwd, file);
 
   let configPath = getConfigPath(config);
   /**
-   * If the file doesn't exist let's check if doesn't exist the DEFAULT_CONFIG_FILE_PATH
+   * If the file doesn't exist let's check if doesn't exist the DEFAULT_CONFIG_FILENAME
    * if so we want to fallback to default configuration (null)
    * if doesn't exist file specified by user we should inform about it
    */
   if (!fs.existsSync(configPath)) {
     if (
-      ![DEFAULT_CONFIG_FILE_PATH, DEPRECATED_DEFAULT_CONFIG_FILE_PATH].includes(
+      ![DEFAULT_CONFIG_FILENAME, DEPRECATED_DEFAULT_CONFIG_FILENAME].includes(
         config
       )
     ) {
@@ -37,14 +37,14 @@ module.exports = function getWebpackConfigPath(
 
     /**
      * For some time we want to check also this:
-     * If we wasn't able to locate DEFAULT_CONFIG_FILE_PATH maybe we could be successful
-     * in search to DEPRECATED_DEFAULT_CONFIG_FILE_PATH, let's return it if we have found it.
+     * If we wasn't able to locate DEFAULT_CONFIG_FILENAME maybe we could be successful
+     * in search to DEPRECATED_DEFAULT_CONFIG_FILENAME, let's return it if we have found it.
      *
-     * Once we are about to remove this we can refactor L13 back to: `if (config !== DEFAULT_CONFIG_FILE_PATH)`
+     * Once we are about to remove this we can refactor L13 back to: `if (config !== DEFAULT_CONFIG_FILENAME)`
      * @deprecated
      */
-    if (fs.existsSync(getConfigPath(DEPRECATED_DEFAULT_CONFIG_FILE_PATH))) {
-      return getConfigPath(DEPRECATED_DEFAULT_CONFIG_FILE_PATH);
+    if (fs.existsSync(getConfigPath(DEPRECATED_DEFAULT_CONFIG_FILENAME))) {
+      return getConfigPath(DEPRECATED_DEFAULT_CONFIG_FILENAME);
     }
 
     /**


### PR DESCRIPTION
I think it's a good idea to search for `webpack.haul.js` which is deprecated config name in favor of `haul.config.js`.

If no config is specified by `--config` Haul will try to find `haul.config.js` first, then it tries to find `webpack.haul.js` if no of them is found he will run in zero-configuration™ mode.

If a user specifies `--config` and that path is non-valid, Haul will throw an error says that.

@satya164 if you are reading this, feel free to rephrase the comments. 💪