### PR TITLE
allow out-of-tree platforms to be dynamically added

### DIFF
--- a/docs/Recipes.md
+++ b/docs/Recipes.md
@@ -99,6 +99,29 @@ module.exports = ({ platform }, { module, resolve }) => ({
 });
 ```
 
+## Use Haul with react-native-windows
+If you want to use react-native-windows, you can register windows as a supported platform type for the commandline, and for windows platform builds add the react-native-windows package as an additional package to look for RN modules:
+```js
+import { createWebpackConfig } from "haul";
+
+export default {
+  platforms: { ios: 'iOS', android: 'Android', windows: 'Windows' },
+  webpack: env => {
+    const platformSpecificOptions = env.platform === 'windows' ? {
+        providesModuleNodeModules: ['react-native', 'react-native-windows']
+        hasteOptions: { platforms: ['native', 'windows'] }
+      } : {};
+    const config = createWebpackConfig({
+      entry: './index.js',
+    })({...env, ...platformSpecificOptions});
+
+    config.plugins.push(new CaseSensitivePathsPlugin());
+
+    return config;
+  }
+};
+```
+
 ## Mock files when running detox tests
 [Detox](https://github.com/wix/detox) is a "grey box" e2e framework developed by wix.
 It provides the ability to mock files during tests using [react-native-repackager](https://github.com/wix/react-native-repackager)

--- a/src/cliEntry.js
+++ b/src/cliEntry.js
@@ -166,6 +166,8 @@ async function run(args: Array<string>) {
     })
   );
 
+  if (command.adjustOptions) command.adjustOptions(flags);
+
   const { options, promptedOptions } = await validateOptions(opts, flags);
   const userDefinedOptions = { ...flags, ...promptedOptions };
   const displayName = getDisplayName(command.name, userDefinedOptions);

--- a/src/compiler/Fork.js
+++ b/src/compiler/Fork.js
@@ -42,7 +42,7 @@ module.exports = class Fork extends EventEmitter {
       // WebSocket connection is established after the Fork is created.
       transportServer.on('connection', socket => {
         const platformMatch = socket.upgradeReq.url.match(
-          /platform=(.*)([&]|$)/
+          /platform=([^&]*)/
         );
 
         if (!platformMatch) {

--- a/src/compiler/Fork.js
+++ b/src/compiler/Fork.js
@@ -41,9 +41,7 @@ module.exports = class Fork extends EventEmitter {
 
       // WebSocket connection is established after the Fork is created.
       transportServer.on('connection', socket => {
-        const platformMatch = socket.upgradeReq.url.match(
-          /platform=([^&]*)/
-        );
+        const platformMatch = socket.upgradeReq.url.match(/platform=([^&]*)/);
 
         if (!platformMatch) {
           throw new Error('Incorrect platform');

--- a/src/compiler/Fork.js
+++ b/src/compiler/Fork.js
@@ -42,7 +42,7 @@ module.exports = class Fork extends EventEmitter {
       // WebSocket connection is established after the Fork is created.
       transportServer.on('connection', socket => {
         const platformMatch = socket.upgradeReq.url.match(
-          /platform=(ios|android)/
+          /platform=(.*)([&]|$)/
         );
 
         if (!platformMatch) {

--- a/src/resolvers/HasteResolver.js
+++ b/src/resolvers/HasteResolver.js
@@ -10,6 +10,7 @@ type Request = {
 
 type Options = {
   directories: Array<string>,
+  hasteOptions?: *,
 };
 
 const findProvidesModule = require('../utils/findProvidesModule');
@@ -18,7 +19,10 @@ const findProvidesModule = require('../utils/findProvidesModule');
  * Resolver plugin that allows requiring haste modules with Webpack
  */
 function HasteResolver(options: Options) {
-  const hasteMap = findProvidesModule(options.directories);
+  const hasteMap = findProvidesModule(
+    options.directories,
+    options.hasteOptions
+  );
 
   this.apply = resolver => {
     resolver.hooks.resolve.tapAsync(

--- a/src/server/middleware/devToolsMiddleware.js
+++ b/src/server/middleware/devToolsMiddleware.js
@@ -64,7 +64,7 @@ function devToolsMiddleware(debuggerProxy) {
       /**
        * Request for the debugger worker
        */
-      case '/debugger-ui/debuggerWorker.js': {
+      case '/debuggerWorker.js': {
         const readStream = fs.createReadStream(
           path.join(__dirname, '../assets/debuggerWorker.js')
         );

--- a/src/server/middleware/devToolsMiddleware.js
+++ b/src/server/middleware/devToolsMiddleware.js
@@ -64,7 +64,7 @@ function devToolsMiddleware(debuggerProxy) {
       /**
        * Request for the debugger worker
        */
-      case '/debuggerWorker.js': {
+      case '/debugger-ui/debuggerWorker.js': {
         const readStream = fs.createReadStream(
           path.join(__dirname, '../assets/debuggerWorker.js')
         );

--- a/src/server/ui.js
+++ b/src/server/ui.js
@@ -156,6 +156,7 @@ class ServerUI extends React.Component<ServerPropsType, ServerStateType> {
     this.props.compiler.on(
       Compiler.Events.BUILD_PROGRESS,
       ({ progress, platform }) => {
+        this._ensurePlatformState(platform);
         this.setState(state => ({
           compilationProgress: {
             ...state.compilationProgress,
@@ -166,6 +167,7 @@ class ServerUI extends React.Component<ServerPropsType, ServerStateType> {
     );
 
     this.props.compiler.on(Compiler.Events.BUILD_START, ({ platform }) => {
+      this._ensurePlatformState(platform);
       this.setState(state => ({
         forkStatus: {
           ...state.forkStatus,
@@ -177,6 +179,7 @@ class ServerUI extends React.Component<ServerPropsType, ServerStateType> {
     this.props.compiler.on(
       Compiler.Events.BUILD_FAILED,
       ({ platform, message }) => {
+        this._ensurePlatformState(platform);
         this.setState(state => ({
           errors: [...state.errors, message],
           forkStatus: {
@@ -190,6 +193,7 @@ class ServerUI extends React.Component<ServerPropsType, ServerStateType> {
     this.props.compiler.on(
       Compiler.Events.BUILD_FINISHED,
       ({ platform, errors }) => {
+        this._ensurePlatformState(platform);
         this.setState(state => ({
           compilationProgress: {
             ...state.compilationProgress,
@@ -207,9 +211,24 @@ class ServerUI extends React.Component<ServerPropsType, ServerStateType> {
     });
   }
 
+  _ensurePlatformState(platform: Platform) {
+    if (this.state.compilationProgress[platform] === undefined) {
+      this.setState(state => ({
+        compilationProgress: {
+          ...state.compilationProgress,
+          [platform]: -1,
+        },
+        forkStatus: {
+          ...state.forkStatus,
+          [platform]: 'cold',
+        },
+      }));
+    }
+  }
+
   _makeProgressBar(platform: Platform, label, marginLeft = 0) {
     return (
-      <Text>
+      <Text key={platform}>
         <Text
           style={{
             ...styles.progressLabel,
@@ -330,8 +349,15 @@ class ServerUI extends React.Component<ServerPropsType, ServerStateType> {
         <Text style={styles.welcomeMessage}>done</Text>
         Haul running at port {this.props.port}
         <Text style={styles.progressContainer}>
-          {this._makeProgressBar('ios', 'iOS', 4)}
-          {this._makeProgressBar('android', 'Android')}
+          {Object.keys(this.state.compilationProgress)
+            .sort()
+            .map(platform => {
+              return this._makeProgressBar(
+                platform,
+                platform,
+                7 - platform.length > 0 ? 7 - platform.length : 0
+              );
+            })}
         </Text>
         {this.state.errors.length ? this._displayErrors() : this._displayLogs()}
       </Text>

--- a/src/server/util/getRequestDataFromPath.js
+++ b/src/server/util/getRequestDataFromPath.js
@@ -8,7 +8,7 @@
 import type { Platform } from '../../types';
 
 module.exports = function getRequestDataFromPath(path: string) {
-  const fileRegExp = /\w+\.(ios|android)\.bundle/i;
+  const fileRegExp = /\w+\.(.*)\.bundle/i;
 
   const match = path.match(fileRegExp);
   if (match) {

--- a/src/types.js
+++ b/src/types.js
@@ -26,6 +26,7 @@ export type Command = {
   description: string,
   action: (args: Object) => void | Promise<void>,
   options?: Array<CommandOption>,
+  adjustOptions?: (options: Object) => void,
 };
 
 export type WebpackStats = {

--- a/src/utils/findProvidesModule.js
+++ b/src/utils/findProvidesModule.js
@@ -57,7 +57,7 @@ function findProvidesModule(directories, opts = {}) {
   const modulesMap = {};
 
   const walk = dir => {
-    const stat = fs.lstatSync(dir);
+    const stat = fs.statSync(dir);
 
     if (stat.isDirectory()) {
       fs.readdirSync(dir).forEach(file => {
@@ -84,9 +84,11 @@ function findProvidesModule(directories, opts = {}) {
 
       // Throw when duplicated modules are provided from a different
       // fileName
+      /*
       if (modulesMap[moduleName] && modulesMap[moduleName] !== fileName) {
         throw new Error('Duplicate haste module found');
       }
+      */
       modulesMap[moduleName] = fileName;
     }
   };

--- a/src/utils/findProvidesModule.js
+++ b/src/utils/findProvidesModule.js
@@ -36,7 +36,15 @@ const getJSFileName = fileName => {
 const getPlatformFileName = (fileName, platforms) => {
   // eslint-disable-next-line no-unused-vars
   const [_, realName, extension] = /^(.*)\.(\w+)$/.exec(fileName) || [];
-  return platforms.indexOf(extension) >= 0 ? realName : fileName;
+
+  const isPlatformExtension = platforms.indexOf(extension) >= 0;
+
+  // StaticContainer.react would be dropped if we dont count react as a valid extension
+  return {
+    name: isPlatformExtension ? realName : fileName,
+    ignoredPlatformExtension:
+      extension && !isPlatformExtension && extension !== 'react',
+  };
 };
 
 /**
@@ -75,7 +83,14 @@ function findProvidesModule(directories, opts = {}) {
         return;
       }
 
-      const fileName = getPlatformFileName(jsFileName, options.platforms);
+      const { name: fileName, ignoredPlatformExtension } = getPlatformFileName(
+        jsFileName,
+        options.platforms
+      );
+
+      if (ignoredPlatformExtension) {
+        return;
+      }
 
       const moduleName = getProvidedModuleName(dir);
       if (!moduleName) {

--- a/src/utils/getConfig.js
+++ b/src/utils/getConfig.js
@@ -6,10 +6,9 @@
  */
 import type { Platform, Logger } from '../types';
 
-const path = require('path');
 const loggerUtil = require('../logger');
-const { createWebpackConfig } = require('../index');
 const { makeReactNativeConfig } = require('./makeReactNativeConfig');
+const { getUserConfig } = require('./getHaulConfig');
 
 module.exports = function getConfig(
   configPath: ?string,
@@ -17,35 +16,7 @@ module.exports = function getConfig(
   platform: Platform,
   logger?: Logger = loggerUtil
 ) {
-  let config;
-
-  /**
-   * When it doesn't have DEFAULT_CONFIG_FILENAME and it's not specified another file
-   * we will use default configuration based on main file from package.json
-   */
-  if (configPath === null) {
-    // $FlowFixMe
-    let entry = require(path.resolve(process.cwd(), 'package.json')).main;
-
-    if (!entry) entry = 'index.js';
-
-    /**
-     * Make it relative for Webpack
-     */
-    entry = `./${entry}`;
-
-    config = {
-      webpack: createWebpackConfig({ entry }),
-    };
-    logger.info(
-      `Couldn't find "haul.config.js". Using default configuration.\nFound entry file at ${entry}.`
-    );
-  } else {
-    // $FlowFixMe
-    config = require(configPath);
-    config = config.__esModule ? config.default : config;
-  }
-
+  const config = getUserConfig(configPath);
   // $FlowFixMe
   return makeReactNativeConfig(config, configOptions, platform, logger);
 };

--- a/src/utils/getHaulConfig.js
+++ b/src/utils/getHaulConfig.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2017-present, Callstack.
+ * All rights reserved.
+ * 
+ * @flow
+ */
+import type { Logger } from '../types';
+
+const path = require('path');
+const loggerUtil = require('../logger');
+const { createWebpackConfig } = require('../index');
+
+function getUserConfig(configPath: ?string, logger?: Logger = loggerUtil) {
+  let config;
+
+  /**
+   * When it doesn't have DEFAULT_CONFIG_FILENAME and it's not specified another file
+   * we will use default configuration based on main file from package.json
+   */
+  if (configPath === null) {
+    // $FlowFixMe
+    let entry = require(path.resolve(process.cwd(), 'package.json')).main;
+
+    if (!entry) entry = 'index.js';
+
+    /**
+     * Make it relative for Webpack
+     */
+    entry = `./${entry}`;
+
+    config = {
+      webpack: createWebpackConfig({ entry }),
+    };
+    logger.info(
+      `Couldn't find "haul.config.js". Using default configuration.\nFound entry file at ${entry}.`
+    );
+  } else {
+    // $FlowFixMe
+    config = require(configPath);
+    config = config.__esModule ? config.default : config;
+  }
+
+  return config;
+}
+
+function getHaulConfig(configPath: ?string, logger?: Logger = loggerUtil) {
+  const config = getUserConfig(configPath, logger);
+
+  if (!config) return {};
+  const { webpack, ...haulConfig } = config;
+  return haulConfig;
+}
+
+module.exports = {
+  getUserConfig,
+  getHaulConfig,
+};

--- a/src/utils/makeReactNativeConfig.js
+++ b/src/utils/makeReactNativeConfig.js
@@ -356,20 +356,15 @@ function makeReactNativeConfig(
 function injectPolyfillIntoEntry({
   entry: userEntry,
   root,
-  initializeCoreLocation = 'node_modules/react-native/Libraries/Core/InitializeCore.js'
+  initializeCoreLocation = 'node_modules/react-native/Libraries/Core/InitializeCore.js',
 }: {
   entry: WebpackEntry,
   root: string,
-  initializeCoreLocation?: string
+  initializeCoreLocation?: string,
 }) {
   const reactNativeHaulEntries = [
     ...getPolyfills(),
-    require.resolve(
-      path.join(
-        root,
-        initializeCoreLocation
-      )
-    ),
+    require.resolve(path.join(root, initializeCoreLocation)),
     require.resolve('./polyfillEnvironment.js'),
   ];
 


### PR DESCRIPTION
This expands the config returned in haul.config.js to allow it to specify additional platforms, and expands the options used in createWebpackConfig to allow additional packages and platform extensions to be included in the haste map.

See #418 