### PR TITLE
Remove webpack entry verification checks

### DIFF
--- a/src/utils/makeReactNativeConfig.js
+++ b/src/utils/makeReactNativeConfig.js
@@ -319,26 +319,6 @@ function makeReactNativeConfig(
     );
   }
 
-  let entries = webpackConfig.entry;
-
-  if (typeof entries === 'string') {
-    entries = [entries];
-  }
-
-  entries.forEach(entry => {
-    if (typeof entry !== 'string') {
-      throw new Error(
-        `The 'entry' property must be a string and point to your app's entry point (usually 'index.js').`
-      );
-    }
-
-    if (!fs.existsSync(path.resolve(root, entry))) {
-      throw new Error(
-        `The file '${entry}' doesn't exist. It should point to your app's entry point (usually 'index.js').`
-      );
-    }
-  });
-
   return webpackConfig;
 }
 

--- a/src/utils/makeReactNativeConfig.js
+++ b/src/utils/makeReactNativeConfig.js
@@ -10,7 +10,6 @@ import type { Logger, Platform } from '../types';
 
 const webpack = require('webpack');
 const path = require('path');
-const fs = require('fs');
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 const AssetResolver = require('../resolvers/AssetResolver');
 const HasteResolver = require('../resolvers/HasteResolver');


### PR DESCRIPTION
This resolves #417.

Since any plugin in a full webpack config _could_ affect module resolution, this change removes the Haul-specific entrypoint verification.