### PR TITLE
Don't use deflate & better socket error handle 

### DIFF
--- a/src/compiler/Compiler.js
+++ b/src/compiler/Compiler.js
@@ -37,6 +37,8 @@ module.exports = class Compiler extends EventEmitter {
         this.forks[platform] = this.initFork({ platform, options });
       }
 
+      if (!this.forks[platform]) return;
+
       // If the fork is compiling the bundle, attach listener to emit `REQUEST_FILE` once
       // the bundle is created, otherwise simply request the file. Callback will be then invoked in
       // `FILE_RECEIVED` listener.

--- a/src/compiler/Compiler.js
+++ b/src/compiler/Compiler.js
@@ -92,7 +92,13 @@ module.exports = class Compiler extends EventEmitter {
    * Create fork process and attach necessary event listeners.
    */
   initFork({ platform, options }: { platform: Platform, options: * }) {
-    const fork = new Fork({ platform, options });
+    let fork;
+    try {
+      fork = new Fork({ platform, options });
+    } catch (err) {
+      this.emit(Events.BUILD_FAILED, { platform, message: err.toString() });
+      return null;
+    }
 
     fork.on(Events.FILE_NOT_FOUND, ({ taskId }) => {
       const { callback, awaitingCount } = this.tasks.pop(taskId);

--- a/src/compiler/Compiler.js
+++ b/src/compiler/Compiler.js
@@ -95,8 +95,8 @@ module.exports = class Compiler extends EventEmitter {
     let fork;
     try {
       fork = new Fork({ platform, options });
-    } catch (err) {
-      this.emit(Events.BUILD_FAILED, { platform, message: err.toString() });
+    } catch (message) {
+      this.emit(Events.BUILD_FAILED, { platform, message });
       return null;
     }
 

--- a/src/compiler/Fork.js
+++ b/src/compiler/Fork.js
@@ -1,7 +1,7 @@
 /**
  * Copyright 2017-present, Callstack.
  * All rights reserved.
- * 
+ *
  * @flow
  */
 
@@ -50,6 +50,13 @@ module.exports = class Fork extends EventEmitter {
         }
 
         forks[platformMatch[1]].setSocket(socket);
+
+        socket.on('error', err => {
+          this.emit(Events.BUILD_FAILED, {
+            message: `Socket: ${err.toString()}`,
+          });
+          throw err;
+        });
       });
     }
 

--- a/src/compiler/Fork.js
+++ b/src/compiler/Fork.js
@@ -53,7 +53,7 @@ module.exports = class Fork extends EventEmitter {
 
         socket.on('error', err => {
           this.emit(Events.BUILD_FAILED, {
-            message: `Socket: ${err.toString()}`,
+            message: `Socket: ${err}`,
           });
           throw err;
         });

--- a/src/compiler/createWebSocketServer.js
+++ b/src/compiler/createWebSocketServer.js
@@ -39,7 +39,11 @@ module.exports = function createWebSocketServer() {
   const socketAddress = getSocketAddress();
 
   const httpServer = http.createServer();
-  const webSocketServer = new Server({ server: httpServer });
+  const webSocketServer = new Server({
+    server: httpServer,
+    perMessageDeflate: false,
+    maxPayload: 200 * 1024 * 1024,
+  });
 
   httpServer.listen(socketAddress);
 


### PR DESCRIPTION
I've discovered that we are using ws@2.2.0 which has the deflate option turned *on* by default. This issue is not actually about deflate but about `maxPayload`. (maxPayload error blown the zlib).

This is supposed to be just a walk around because I'm still not sure how the size is computed thought.

- My test project should be 42 633 230 byte. _(this is in Haul's logs or when I dowload the bundle into file via `wget -O bundle http://localhost:8081/index.ios.bundle` or something)_
- Default `maxPayload` ws@2.2.0 is 104 857 600 byte. (https://github.com/websockets/ws/blob/2.2.0/lib/WebSocketServer.js#L46)
- However, the `ws` claim that the bundle file is 144 242 145 byte (I had loged this in the context of very ws itself: https://github.com/websockets/ws/blob/2.2.0/lib/Receiver.js#L467).

I have also created new branch where I'm going to upgrade ws to latest version https://github.com/callstack/haul/tree/jukben/ws-upgrade

For context: https://github.com/websockets/ws/issues/1136

Not sure if this issue could be related to [memory-fs](https://github.com/webpack/memory-fs) what we use.

CLOSE #429 
