### PR TITLE
Run adb reverse when platform is 'all'

### DIFF
--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -63,7 +63,7 @@ async function start(opts: *) {
   }
 
   // Run `adb reverse` on Android
-  if (opts.platform === 'android') {
+  if (opts.platform === 'android' || opts.platform === 'all') {
     const command = `adb reverse tcp:${opts.port} tcp:${opts.port}`;
 
     try {


### PR DESCRIPTION
`adb reverse` is only run when `platform` is `android`, it should be run if `platform` is `all` also.