### PR TITLE
Updating TypeScript configuration to the new style in Recipes

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -51,7 +51,7 @@ export default {
 };
 ```
 
-If you are want to customize the Webpack configuration, like `loaders` etc., you can use this approach, then you can mutate config as you want.
+If you want to customize the Webpack configuration, like `loaders` etc., you can use this approach, then you can mutate config as you want.
 
 ```js
 import { createWebpackConfig } from "haul";

--- a/docs/Recipes.md
+++ b/docs/Recipes.md
@@ -8,7 +8,7 @@ You will need to install `ts-loader` for Haul to work with TypeScript.
 
 ```yarn add --dev ts-loader```
 
-This is a `webpack.haul.js` that works with TypeScript.
+This is a `haul.config.js` that works with TypeScript.
 ```javascript
 import { createWebpackConfig } from "haul";
 
@@ -66,7 +66,7 @@ You will need `babel-loader` for this.
 
 ```yarn add --dev babel-loader```
 
-Revised `webpack.haul.js`
+Revised `haul.config.js`
 
 ```javascript
 import { createWebpackConfig } from "haul";
@@ -116,8 +116,7 @@ react-native-repackager is built for the standard react-native packager, so your
 
 
 ```javascript
-
-// webpack.haul.js
+// haul.config.js
 
 resolve: {
     ...defaults.resolve,
@@ -125,8 +124,6 @@ resolve: {
             ? ['.mock.behaviour.js', ...defaults.resolve.extensions]
             : defaults.resolve.extensions
   },
-
-
 ```
 
 Set the environment variable `APP_ENV` to

--- a/docs/Recipes.md
+++ b/docs/Recipes.md
@@ -10,31 +10,35 @@ You will need to install `ts-loader` for Haul to work with TypeScript.
 
 This is a `webpack.haul.js` that works with TypeScript.
 ```javascript
-module.exports = ({ platform }, { module, resolve }) => ({
-  entry: `./src/index.${platform}.tsx`,
-  module: {
-    ...module,
-    rules: [
+import { createWebpackConfig } from "haul";
+
+export default {
+  webpack: env => {
+    const config = createWebpackConfig({
+      entry: `./src/index.${env.platform}.tsx`,
+    })(env);
+
+    config.module.rules = [
       {
         test: /\.tsx?$/,
         loader: 'ts-loader'
       },
-      ...module.rules
-    ]
-  },
-  resolve: {
-    ...resolve,
-    extensions: [
+      ...config.module.rules,
+    ];
+
+    config.resolve.extensions = [
       '.ts',
       '.tsx',
-      `.${platform}.ts`,
+      `.${env.platform}.ts`,
       '.native.ts',
-      `.${platform}.tsx`,
+      `.${env.platform}.tsx`,
       '.native.tsx',
-      ...resolve.extensions
+      ...config.resolve.extensions,
     ]
+
+    return config;
   }
-});
+};
 ```
 
 And a corresponding (example) `tsconfig.json`
@@ -65,11 +69,15 @@ You will need `babel-loader` for this.
 Revised `webpack.haul.js`
 
 ```javascript
-module.exports = ({ platform }, { module, resolve }) => ({
-  entry: `./src/index.${platform}.tsx`,
-  module: {
-    ...module,
-    rules: [
+import { createWebpackConfig } from "haul";
+
+export default {
+  webpack: env => {
+    const config = createWebpackConfig({
+      entry: `./src/index.${env.platform}.tsx`,
+    })(env);
+
+    config.module.rules = [
       {
         test: /\.tsx?$/,
         exclude: '/node_modules/',
@@ -78,25 +86,26 @@ module.exports = ({ platform }, { module, resolve }) => ({
             loader: 'babel-loader',
           },
           {
-            loader: 'ts-loader'
-          },
-        ],
+            loader: 'ts-loader',
+          }
+        ]
       },
-      ...module.rules
-    ]
-  },
-  resolve: {
-    ...resolve,
-    extensions: [
+      ...config.module.rules,
+    ];
+
+    config.resolve.extensions = [
       '.ts',
       '.tsx',
-      `.${platform}.ts`,
+      `.${env.platform}.ts`,
       '.native.ts',
-      `.${platform}.tsx`,
+      `.${env.platform}.tsx`,
       '.native.tsx',
-      ...resolve.extensions],
-  },
-});
+      ...config.resolve.extensions,
+    ]
+
+    return config;
+  }
+};
 ```
 
 ## Mock files when running detox tests


### PR DESCRIPTION
Hello there!
Looks like there's a new configuration style for haul and unfortunately `Recipes.md` with TypeScript setup was forgotten. The old one still works but it's showing deprecation warning. I had a moment to play with it a bit more and eventually I got it to work. Doing this PR, in case anyone alse might find it useful.