### PR TITLE
update `haul init` output to match new spec (#441)

### DIFF
--- a/integration_tests/__tests__/__snapshots__/init.test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/init.test.js.snap
@@ -1,7 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`init command on react-native project 1`] = `
-"module.exports = ({ platform }) => ({
-  entry: \`./index.js\`,
-});"
+"import { createWebpackConfig } from \\"haul\\";
+
+export default {
+  webpack: createWebpackConfig(({ platform }) => ({
+    entry: \`./index.js\`
+  }))
+};"
 `;

--- a/integration_tests/__tests__/init.test.js
+++ b/integration_tests/__tests__/init.test.js
@@ -15,7 +15,7 @@ const TEST_PROJECT_DIR = path.resolve(
   __dirname,
   '../../fixtures/react-native-clean'
 );
-const CONFIG_FILE_PATH = path.resolve(TEST_PROJECT_DIR, 'webpack.haul.js');
+const CONFIG_FILE_PATH = path.resolve(TEST_PROJECT_DIR, 'haul.config.js');
 const GRADLE_PATH = path.resolve(TEST_PROJECT_DIR, 'android/app/build.gradle');
 const ENTER_KEY = '\x0d';
 

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -15,6 +15,7 @@ const inquirer = require('inquirer');
 const semver = require('semver');
 const getReactNativeVersion = require('../utils/getReactNativeVersion');
 
+const constants = require('../constants');
 const messages = require('../messages');
 
 async function init() {
@@ -32,8 +33,8 @@ async function init() {
     process.exit(1);
   }
 
-  // Does `webpack.haul.js` already exist?
-  if (fs.existsSync(path.join(cwd, 'webpack.haul.js'))) {
+  // Does `haul.config.js` already exist?
+  if (fs.existsSync(path.join(cwd, constants.DEFAULT_CONFIG_FILENAME))) {
     const result = await inquirer.prompt([
       {
         type: 'confirm',
@@ -60,7 +61,7 @@ async function init() {
   } else {
     const list = fs
       .readdirSync(cwd)
-      .filter(f => /\.js$/.test(f) && f !== 'webpack.haul.js');
+      .filter(f => /\.js$/.test(f) && f !== constants.DEFAULT_CONFIG_FILENAME);
 
     if (list.length <= 5) {
       const result = await inquirer.prompt([
@@ -130,12 +131,16 @@ async function init() {
   await new Promise(resolve => setTimeout(resolve, 1000));
 
   const config = dedent`
-    module.exports = ({ platform }) => ({
-      entry: \`./${entry}\`,
-    });
+    import { createWebpackConfig } from "haul";
+
+    export default {
+      webpack: createWebpackConfig(({ platform }) => ({
+        entry: \`./${entry}\`
+      }))
+    };
   `;
 
-  fs.writeFileSync(path.join(cwd, 'webpack.haul.js'), config);
+  fs.writeFileSync(path.join(cwd, constants.DEFAULT_CONFIG_FILENAME), config);
 
   progress.succeed(messages.generatedConfig());
 }

--- a/src/messages/generatedConfig.js
+++ b/src/messages/generatedConfig.js
@@ -7,4 +7,7 @@
 
 const chalk = require('chalk');
 
-module.exports = () => `Generated ${chalk.bold('webpack.haul.js')}`;
+const constants = require('../constants');
+
+module.exports = () =>
+  `Generated ${chalk.bold(constants.DEFAULT_CONFIG_FILENAME)}`;


### PR DESCRIPTION
Fixes #441.

Updates init command to output haul.config.js instead of webpack.haul.js, as well as referencing src/constants.js for easier future updates.