### PR TITLE
Resolve path to `react-native` preset

### DIFF
--- a/src/utils/__tests__/__snapshots__/getBabelConfig.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/getBabelConfig.test.js.snap
@@ -8,7 +8,7 @@ Object {
     "<<REPLACED>>/hot/babelPlugin.js",
   ],
   "presets": Array [
-    "react-native",
+    "<<NODE_MODULE>>/babel-preset-react-native/index.js",
   ],
 }
 `;
@@ -19,7 +19,7 @@ Object {
     "<<REPLACED>>/utils/fixRequireIssues.js",
   ],
   "presets": Array [
-    "react-native",
+    "<<NODE_MODULE>>/babel-preset-react-native/index.js",
   ],
 }
 `;

--- a/src/utils/getBabelConfig.js
+++ b/src/utils/getBabelConfig.js
@@ -9,7 +9,7 @@ const fs = require('fs');
 const path = require('path');
 
 const DEFAULT_BABELRC = {
-  presets: ['react-native'],
+  presets: [require.resolve('babel-preset-react-native')],
 };
 
 module.exports = function getBabelConfig(cwd: string) {


### PR DESCRIPTION
When running `haul` within a monorepo, the default behavior is to compile everything which is not in `node_modules` (with a few [exceptions](https://github.com/callstack/haul/blob/master/src/utils/makeReactNativeConfig.js#L78)). Webpack will use the realpath rather than the symlink path when processing rule `excludes`. As a result, any sibling packages within a monorepo gets compiled (this is desired behavior in my case).

Where the issue arrises, is that babel looks to resolve presets/plugins relative to the [file being transformed](https://github.com/babel/babel/issues/2974#issuecomment-155738271). It doesn't make sense for packages agnostic of distribution (web, native, etc...) to have to define `babel-preset-react-native` as a dependency. This should only be required within the react-native project itself.

By using an absolute path, we bypass any babel specific resolution logic, and instead resolve a single time relative to the project root using the native nodejs resolution algorithm.