### PR TITLE
Upgrade upath in lockfile

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7373,8 +7373,8 @@ unset-value@^1.0.0:
     isobject "^3.0.0"
 
 upath@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/upath/-/upath-1.0.4.tgz#ee2321ba0a786c50973db043a50b7bcba822361d"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
 
 urix@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Follow-up from #454. This resolves the following error on Node 10:

```
error upath@1.0.4: The engine "node" is incompatible with this module. Expected version ">=4 <=9".
```