### PR TITLE
Fix minimization of bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "source-map": "^0.5.6",
     "strip-ansi": "^3.0.1",
     "thread-loader": "^1.1.5",
+    "uglifyjs-webpack-plugin": "^1.2.7",
     "webpack": "^4.12.0",
     "webpack-hot-middleware": "^2.22.1",
     "ws": "^2.2.2",

--- a/src/utils/__tests__/__snapshots__/getConfig.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/getConfig.test.js.snap
@@ -5,7 +5,7 @@ exports[`creates config: diff ios/android config 1`] = `
 - First value
 + Second value
 
-@@ -44,25 +44,25 @@
+@@ -44,18 +44,18 @@
           \\"test\\": /\\\\.(aac|aiff|bmp|caf|gif|html|jpeg|jpg|m4a|m4v|mov|mp3|mp4|mpeg|mpg|obj|otf|pdf|png|psd|svg|ttf|wav|webm|webp)$/,
           \\"use\\": Object {
             \\"loader\\": \\"<<REPLACED>>/loaders/assetLoader.js\\",
@@ -24,6 +24,11 @@ exports[`creates config: diff ios/android config 1`] = `
     \\"optimization\\": Object {
       \\"concatenateModules\\": true,
       \\"minimize\\": false,
+      \\"minimizer\\": Array [
+        UglifyJsPlugin {
+@@ -80,11 +80,11 @@
+        },
+      ],
       \\"namedModules\\": true,
     },
     \\"output\\": Object {
@@ -34,7 +39,7 @@ exports[`creates config: diff ios/android config 1`] = `
     },
     \\"plugins\\": Array [
       CaseSensitivePathsPlugin {
-@@ -126,11 +126,11 @@
+@@ -148,11 +148,11 @@
     \\"resolve\\": Object {
       \\"alias\\": Object {
         \\"react-proxy\\": \\"@zamotany/react-proxy\\",
@@ -109,6 +114,28 @@ Object {
   "optimization": Object {
     "concatenateModules": true,
     "minimize": false,
+    "minimizer": Array [
+      UglifyJsPlugin {
+        "options": Object {
+          "cache": true,
+          "exclude": undefined,
+          "extractComments": false,
+          "include": undefined,
+          "parallel": true,
+          "sourceMap": true,
+          "test": /\\\\\\.\\(js\\|\\(js\\)\\?bundle\\)\\(\\$\\|\\\\\\?\\)/i,
+          "uglifyOptions": Object {
+            "compress": Object {
+              "inline": 1,
+            },
+            "output": Object {
+              "comments": /\\^\\\\\\*\\*!\\|@preserve\\|@license\\|@cc_on/,
+            },
+          },
+          "warningsFilter": [Function],
+        },
+      },
+    ],
     "namedModules": true,
   },
   "output": Object {

--- a/src/utils/__tests__/__snapshots__/makeReactNativeConfig.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/makeReactNativeConfig.test.js.snap
@@ -5,7 +5,7 @@ exports[`makeReactNativeConfig creates config from defaults: diff ios/android co
 - First value
 + Second value
 
-@@ -44,25 +44,25 @@
+@@ -44,18 +44,18 @@
           \\"test\\": /\\\\.(aac|aiff|bmp|caf|gif|html|jpeg|jpg|m4a|m4v|mov|mp3|mp4|mpeg|mpg|obj|otf|pdf|png|psd|svg|ttf|wav|webm|webp)$/,
           \\"use\\": Object {
             \\"loader\\": \\"<<REPLACED>>/loaders/assetLoader.js\\",
@@ -24,6 +24,11 @@ exports[`makeReactNativeConfig creates config from defaults: diff ios/android co
     \\"optimization\\": Object {
       \\"concatenateModules\\": true,
       \\"minimize\\": false,
+      \\"minimizer\\": Array [
+        UglifyJsPlugin {
+@@ -80,11 +80,11 @@
+        },
+      ],
       \\"namedModules\\": true,
     },
     \\"output\\": Object {
@@ -34,7 +39,7 @@ exports[`makeReactNativeConfig creates config from defaults: diff ios/android co
     },
     \\"plugins\\": Array [
       CaseSensitivePathsPlugin {
-@@ -126,11 +126,11 @@
+@@ -148,11 +148,11 @@
     \\"resolve\\": Object {
       \\"alias\\": Object {
         \\"react-proxy\\": \\"@zamotany/react-proxy\\",

--- a/src/utils/makeReactNativeConfig.js
+++ b/src/utils/makeReactNativeConfig.js
@@ -11,6 +11,7 @@ import type { Logger, Platform } from '../types';
 const webpack = require('webpack');
 const path = require('path');
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const AssetResolver = require('../resolvers/AssetResolver');
 const HasteResolver = require('../resolvers/HasteResolver');
 const moduleResolve = require('./resolveModule');
@@ -52,6 +53,7 @@ type WebpackConfig = {
   context: string,
   optimization: {
     minimize: boolean,
+    minimizer: WebpackPlugin[],
     namedModules: boolean,
     concatenateModules: boolean,
   },
@@ -208,6 +210,14 @@ const getDefaultConfig = ({
     },
     optimization: {
       minimize: !!minify,
+      minimizer: [
+        new UglifyJsPlugin({
+          test: /\.(js|(js)?bundle)($|\?)/i,
+          cache: true,
+          parallel: true,
+          sourceMap: true,
+        }),
+      ],
       namedModules: true,
       concatenateModules: true,
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7331,6 +7331,19 @@ uglifyjs-webpack-plugin@^1.2.4:
     webpack-sources "^1.1.0"
     worker-farm "^1.5.2"
 
+uglifyjs-webpack-plugin@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.7.tgz#57638dd99c853a1ebfe9d97b42160a8a507f9d00"
+  dependencies:
+    cacache "^10.0.4"
+    find-cache-dir "^1.0.0"
+    schema-utils "^0.4.5"
+    serialize-javascript "^1.4.0"
+    source-map "^0.6.1"
+    uglify-es "^3.3.4"
+    webpack-sources "^1.1.0"
+    worker-farm "^1.5.2"
+
 uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"


### PR DESCRIPTION
The default `minimizer` created by Webpack does not provide a `test` options, so the default tests just for `.js` files. Since we rely on a different extension for our output bundles, we need to explicitly use `UglifyJsPlugin` ourselves.

Fixes #458