### PR TITLE
Fix for RN Debugger

### DIFF
--- a/src/utils/polyfillEnvironment.js
+++ b/src/utils/polyfillEnvironment.js
@@ -49,7 +49,8 @@ if (process.env.NODE_ENV !== 'production') {
   if (typeof window !== 'undefined' && window.location) {
     protocol = window.location.protocol;
     origin = window.location.host;
-  } else {
+  }
+  if (!protocol || !protocol.startsWith('http')) {
     // In order to ensure hot client has a valid URL we need to get a valid origin
     // from URL from which the bundle was loaded. When using iOS simulator/Android emulator
     // or Android device it will be `localhost:<port>` but when using real iOS device


### PR DESCRIPTION
RN Debugger uses `file://` as its `window.location`.