### PR TITLE
Re-add missing class properties transform

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     ],
     "plugins": [
       "transform-flow-strip-types",
+      "transform-class-properties",
       "transform-object-rest-spread",
       "transform-react-jsx"
     ]


### PR DESCRIPTION
There is a problem on this line:
https://github.com/callstack/haul/blob/d795af385dfb5e3e8a2ef5ceb405aff8ab15933a/src/hot/client/hotApi.js#L34-L36
Re-adding `transform-class-properties` resolved it.