### PR TITLE
Move artifact IO stream logs out of node_modules

### DIFF
--- a/src/server/ui.js
+++ b/src/server/ui.js
@@ -17,8 +17,8 @@ const emoji = require('node-emoji');
 const Compiler = require('../compiler/Compiler');
 const logger = require('../logger');
 
-const outStream = 'node_modules/.haul-artifacts/stdout.log';
-const errStream = 'node_modules/.haul-artifacts/stderr.log';
+const outStream = '.haul-artifacts/stdout.log';
+const errStream = '.haul-artifacts/stderr.log';
 
 /**
  * Create and render React-powered UI for Haul packager server.


### PR DESCRIPTION
For some weird reasons, on Windows, these two artifact files, std{err|out}.log, are locked so I cannot proceed with my package installation while the server is online. It is better to leave it out of node_modules.