### PR TITLE
Place the cache-loader cache inside the .cache subfolder within node_…

### DIFF
--- a/src/utils/__tests__/__snapshots__/getConfig.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/getConfig.test.js.snap
@@ -5,7 +5,7 @@ exports[`creates config: diff ios/android config 1`] = `
 - First value
 + Second value
 
-@@ -54,18 +54,18 @@
+@@ -57,18 +57,18 @@
           \\"test\\": /\\\\.(aac|aiff|bmp|caf|gif|html|jpeg|jpg|m4a|m4v|mov|mp3|mp4|mpeg|mpg|obj|otf|pdf|png|psd|svg|ttf|wav|webm|webp)$/,
           \\"use\\": Object {
             \\"loader\\": \\"<<REPLACED>>/src/loaders/assetLoader.js\\",
@@ -26,7 +26,7 @@ exports[`creates config: diff ios/android config 1`] = `
       \\"minimize\\": false,
       \\"minimizer\\": Array [
         UglifyJsPlugin {
-@@ -90,11 +90,11 @@
+@@ -93,11 +93,11 @@
         },
       ],
       \\"namedModules\\": true,
@@ -39,7 +39,7 @@ exports[`creates config: diff ios/android config 1`] = `
     },
     \\"plugins\\": Array [
       CaseSensitivePathsPlugin {
-@@ -158,11 +158,11 @@
+@@ -161,11 +161,11 @@
     \\"resolve\\": Object {
       \\"alias\\": Object {
         \\"react-proxy\\": \\"@zamotany/react-proxy\\",
@@ -86,6 +86,9 @@ Object {
         "use": Array [
           Object {
             "loader": "<<NODE_MODULE>>/cache-loader/dist/cjs.js",
+            "options": Object {
+              "cacheDirectory": "<<NODE_MODULE>>/.cache/cache-loader",
+            },
           },
           Object {
             "loader": "<<NODE_MODULE>>/thread-loader/dist/cjs.js",

--- a/src/utils/__tests__/__snapshots__/makeReactNativeConfig.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/makeReactNativeConfig.test.js.snap
@@ -5,7 +5,7 @@ exports[`makeReactNativeConfig creates config from defaults: diff ios/android co
 - First value
 + Second value
 
-@@ -54,18 +54,18 @@
+@@ -57,18 +57,18 @@
           \\"test\\": /\\\\.(aac|aiff|bmp|caf|gif|html|jpeg|jpg|m4a|m4v|mov|mp3|mp4|mpeg|mpg|obj|otf|pdf|png|psd|svg|ttf|wav|webm|webp)$/,
           \\"use\\": Object {
             \\"loader\\": \\"<<REPLACED>>/src/loaders/assetLoader.js\\",
@@ -26,7 +26,7 @@ exports[`makeReactNativeConfig creates config from defaults: diff ios/android co
       \\"minimize\\": false,
       \\"minimizer\\": Array [
         UglifyJsPlugin {
-@@ -90,11 +90,11 @@
+@@ -93,11 +93,11 @@
         },
       ],
       \\"namedModules\\": true,
@@ -39,7 +39,7 @@ exports[`makeReactNativeConfig creates config from defaults: diff ios/android co
     },
     \\"plugins\\": Array [
       CaseSensitivePathsPlugin {
-@@ -158,11 +158,11 @@
+@@ -161,11 +161,11 @@
     \\"resolve\\": Object {
       \\"alias\\": Object {
         \\"react-proxy\\": \\"@zamotany/react-proxy\\",

--- a/src/utils/makeReactNativeConfig.js
+++ b/src/utils/makeReactNativeConfig.js
@@ -101,6 +101,9 @@ const getDefaultConfig = ({
           use: [
             {
               loader: require.resolve('cache-loader'),
+              options: {
+                cacheDirectory: path.join(root, 'node_modules/.cache/cache-loader'),
+              }
             },
             {
               loader: require.resolve('thread-loader'),

--- a/src/utils/makeReactNativeConfig.js
+++ b/src/utils/makeReactNativeConfig.js
@@ -101,9 +101,12 @@ const getDefaultConfig = ({
           use: [
             {
               loader: require.resolve('cache-loader'),
-              options: {
-                cacheDirectory: path.join(root, 'node_modules/.cache/cache-loader'),
-              }
+			  options: {
+                cacheDirectory: path.join(
+                  root,
+                  'node_modules/.cache/cache-loader'
+                ),
+			  },
             },
             {
               loader: require.resolve('thread-loader'),

--- a/src/utils/makeReactNativeConfig.js
+++ b/src/utils/makeReactNativeConfig.js
@@ -101,12 +101,12 @@ const getDefaultConfig = ({
           use: [
             {
               loader: require.resolve('cache-loader'),
-			  options: {
+              options: {
                 cacheDirectory: path.join(
                   root,
                   'node_modules/.cache/cache-loader'
                 ),
-			  },
+              },
             },
             {
               loader: require.resolve('thread-loader'),


### PR DESCRIPTION
Change the default cache location for the default 'cache-loader' to avoid it landing inside the local package and needing to add it to gitignore. 
Based on quick discussion with thymikee in chat room.