### PR TITLE
Force js files to use LF even on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js        text eol=lf


### PR DESCRIPTION
All the lint rules blow up if you use CRLF, making working with the repo on windows very annoying.
This forces windows machines to keep the js files with LF when cloning the repo.