### PR TITLE
Modify tests to work on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js        text eol=lf

--- a/integration_tests/__tests__/bundle/bundle.android.test.js
+++ b/integration_tests/__tests__/bundle/bundle.android.test.js
@@ -6,10 +6,10 @@
  */
 
 const fs = require('fs');
-const { run } = require('../../utils');
+const { run, yarnCommand } = require('../../utils');
 const { bundleForPlatform, TEST_PROJECT_DIR, cleanup } = require('./utils');
 
-beforeAll(() => run('yarn --mutex network', TEST_PROJECT_DIR));
+beforeAll(() => run(`${yarnCommand} --mutex network`, TEST_PROJECT_DIR));
 beforeEach(() => cleanup('android'));
 afterAll(() => cleanup('android'));
 

--- a/integration_tests/__tests__/bundle/bundle.ios.test.js
+++ b/integration_tests/__tests__/bundle/bundle.ios.test.js
@@ -6,10 +6,10 @@
  */
 
 const fs = require('fs');
-const { run } = require('../../utils');
+const { run, yarnCommand } = require('../../utils');
 const { bundleForPlatform, TEST_PROJECT_DIR, cleanup } = require('./utils');
 
-beforeAll(() => run('yarn --mutex network', TEST_PROJECT_DIR));
+beforeAll(() => run(`${yarnCommand} --mutex network`, TEST_PROJECT_DIR));
 beforeEach(() => cleanup('ios'));
 afterAll(() => cleanup('ios'));
 

--- a/integration_tests/__tests__/init.test.js
+++ b/integration_tests/__tests__/init.test.js
@@ -8,7 +8,7 @@
 const fs = require('fs');
 const path = require('path');
 const rimraf = require('rimraf');
-const { run } = require('../utils');
+const { run, yarnCommand } = require('../utils');
 const { runHaul } = require('../runHaul');
 
 const TEST_PROJECT_DIR = path.resolve(
@@ -19,7 +19,7 @@ const CONFIG_FILE_PATH = path.resolve(TEST_PROJECT_DIR, 'haul.config.js');
 const GRADLE_PATH = path.resolve(TEST_PROJECT_DIR, 'android/app/build.gradle');
 const ENTER_KEY = '\x0d';
 
-beforeAll(() => run('yarn --mutex network', TEST_PROJECT_DIR));
+beforeAll(() => run(`${yarnCommand} --mutex network`, TEST_PROJECT_DIR));
 afterEach(() => rimraf.sync(CONFIG_FILE_PATH));
 beforeEach(() => rimraf.sync(CONFIG_FILE_PATH));
 afterAll(() => run(`git checkout ${GRADLE_PATH}`));

--- a/integration_tests/__tests__/start.test.js
+++ b/integration_tests/__tests__/start.test.js
@@ -9,7 +9,7 @@ const { runHaul } = require('../runHaul');
 const { cleanup } = require('../utils');
 const path = require('path');
 const os = require('os');
-const { run } = require('../utils');
+const { run, yarnCommand } = require('../utils');
 const fetch = require('node-fetch');
 const stripAnsi = require('strip-ansi');
 const { isPortTaken } = require('../../src/utils/haulPortHandler');
@@ -27,7 +27,7 @@ beforeAll(async done => {
     done.fail('Port is already in use. Cannot run Haul in test env');
   }
 
-  run('yarn --mutex network', TEST_PROJECT_DIR);
+  run(`${yarnCommand} --mutex network`, TEST_PROJECT_DIR);
   haul = runHaul(TEST_PROJECT_DIR, ['start']);
 
   const messageBuffer = [];

--- a/integration_tests/runHaul.js
+++ b/integration_tests/runHaul.js
@@ -32,7 +32,8 @@ function runHaulSync(
   const env = options.nodePath
     ? Object.assign({}, process.env, { NODE_PATH: options.nodePath })
     : process.env;
-  const result = spawnSync(BIN_PATH, args || [], { cwd, env });
+
+  const result = spawnSync('node', [BIN_PATH, ...(args || [])], { cwd, env });
 
   result.stdout = result.stdout.toString();
   result.stderr = result.stderr.toString();
@@ -56,7 +57,7 @@ function runHaul(
     ? Object.assign({}, process.env, { NODE_PATH: options.nodePath })
     : process.env;
 
-  return spawn(BIN_PATH, args || [], { cwd, env });
+  return spawn('node', [BIN_PATH, ...(args || [])], { cwd, env });
 }
 
 module.exports = {

--- a/integration_tests/utils.js
+++ b/integration_tests/utils.js
@@ -13,6 +13,8 @@ const path = require('path');
 const mkdirp = require('mkdirp');
 const rimraf = require('rimraf');
 
+const yarnCommand = process.platform === 'win32' ? 'yarn.cmd' : 'yarn';
+
 const run = (cmd: string, cwd?: string) => {
   const args = cmd.split(/\s/).slice(1);
   const spawnOptions = { cwd };
@@ -117,4 +119,5 @@ module.exports = {
   run,
   writeFiles,
   replaceTestPath,
+  yarnCommand,
 };

--- a/jest/helpers.js
+++ b/jest/helpers.js
@@ -19,10 +19,22 @@ const replacePathsInObject = (object: mixed) => {
     entry =>
       typeof entry === 'string'
         ? entry
+            .replace(
+              new RegExp(`^${excapeStringRegex(path.resolve('/'))}`),
+              '/'
+            )
+            .replace(new RegExp('\\\\', 'g'), '/')
             .replace(/\/.*\/node_modules/, '<<NODE_MODULE>>')
             .replace(
               new RegExp(
-                `^${excapeStringRegex(path.resolve(__dirname, '..'))}`
+                process.platform === 'win32'
+                  ? `^${excapeStringRegex(
+                      path
+                        .resolve(__dirname, '..')
+                        .slice(2)
+                        .replace(new RegExp('\\\\', 'g'), '/')
+                    )}`
+                  : `^${excapeStringRegex(path.resolve(__dirname, '..'))}`
               ),
               '<<REPLACED>>'
             )

--- a/src/compiler/worker/runWebpackCompiler.js
+++ b/src/compiler/worker/runWebpackCompiler.js
@@ -43,7 +43,6 @@ module.exports = function runWebpackCompiler({
   const config = getConfig(
     configPath,
     configOptions,
-    // $FlowFixMe
     (platform: Platform),
     // $FlowFixMe
     (loggerProxy: Logger)

--- a/src/utils/__tests__/getEntryFiles.test.js
+++ b/src/utils/__tests__/getEntryFiles.test.js
@@ -10,7 +10,7 @@ const path = require('path');
 const dedent = require('dedent');
 
 const fakePolyfill = 'polyfill/to/remove';
-const fakeCwd = '/usr/fake';
+const fakeCwd = path.resolve('/usr/fake');
 
 const originalCWD = process.cwd;
 


### PR DESCRIPTION
This makes a couple of minor modifications to allow the tests and snapshots to work on windows.

- Use `yarn.cmd` instead of `yarn` when using spawn on windows.
- Use `node haul/cli.js` instead of just `haul.cli.js` to run haul
- Use some additional substitutions when outputting the snapshot files, so that windows machines get the same result (Mostly logic around the root directory format, and of course the directory separators.

