### PR TITLE
fix makeHot

### DIFF
--- a/docs/HMR_react-navigation.md
+++ b/docs/HMR_react-navigation.md
@@ -73,7 +73,9 @@ const MyApp = StackNavigator({
 AppRegistry.registerComponent('MyApp', () => MyApp);
 ```
 
-Then, wrap those screen factories with `makeHot` call and pass the name of the screen as a second argument:
+Since a comparison is made of the results of `getScreen` each time the drawer is toggled, we need to make sure that subsequent calls of our function return the same value. 
+
+To do this, we need to create our `HotViews` then provide them as a result to `getScreen`.  
 
 ```diff
 // index.js
@@ -86,15 +88,22 @@ import { StackNavigator } from 'react-navigation';
 import HomeScreen from './src/HomeScreen';
 import SecondScreen from './src/SecondScreen';
 
++ const HotViews = {
++   Home: makeHot(() => HomeScreen, 'Home'),
++   Second: makeHot(() => SecondScreen, 'Second')
++ };
+
 const MyApp = StackNavigator({
 -   Home: { getScreen: () => HomeScreen },
 -   Second: { getScreen: () => SecondScreen },
-+   Home: { getScreen: makeHot(() => HomeScreen, 'Home') },
-+   Second: { getScreen: makeHot(() => SecondScreen, 'Second') },
++   Home: { getScreen: HotViews.Home },
++   Second: { getScreen: HotViews.Second },
 });
 
 AppRegistry.registerComponent('MyApp', () => MyApp);
 ```
+
+> When doing this it ensures that `HotViews.Home() === HotViews.Home()` so that unnecessary re-renders do not occur.
 
 ---
 

--- a/src/hot/client/hotApi.js
+++ b/src/hot/client/hotApi.js
@@ -28,69 +28,66 @@ type State = {
  */
 export function makeHot(initialRootFactory: Function, id?: string = 'default') {
   instances[id] = [];
+  class HotWrapper extends Component<*, State> {
+    state = {
+      error: null,
+    };
 
-  return () => {
-    class HotWrapper extends Component<*, State> {
-      state = {
-        error: null,
-      };
+    rootComponentFactory: ?Function;
 
-      rootComponentFactory: ?Function;
+    constructor(props: *) {
+      super(props);
 
-      constructor(props: *) {
-        super(props);
+      const pendingRedraw = pendingRedraws[id];
+      delete pendingRedraws[id];
 
-        const pendingRedraw = pendingRedraws[id];
-        delete pendingRedraws[id];
-
-        instances[id].push(this);
-        this.rootComponentFactory = pendingRedraw || null;
-      }
-
-      _resetError() {
-        this.setState({ error: null });
-        resetRedBox();
-      }
-
-      _redraw(rootComponentFactory?: Function) {
-        if (rootComponentFactory) {
-          this.rootComponentFactory = rootComponentFactory;
-        }
-
-        this._resetError();
-        deepForceUpdate(this);
-      }
-
-      componentWillReceiveProps() {
-        this._resetError();
-        deepForceUpdate(this);
-      }
-
-      componentWillUnmount() {
-        instances[id] = instances[id].filter(instance => instance !== this);
-      }
-
-      componentDidCatch(error: Object) {
-        this.setState({
-          error,
-        });
-      }
-
-      render() {
-        if (this.state.error) {
-          console.error(this.state.error);
-          return null;
-        }
-
-        const Root = this.rootComponentFactory
-          ? this.rootComponentFactory()
-          : initialRootFactory();
-        return <Root {...this.props} />;
-      }
+      instances[id].push(this);
+      this.rootComponentFactory = pendingRedraw || null;
     }
 
-    return hoistNonReactStatic(HotWrapper, initialRootFactory());
-  };
+    _resetError() {
+      this.setState({ error: null });
+      resetRedBox();
+    }
+
+    _redraw(rootComponentFactory?: Function) {
+      if (rootComponentFactory) {
+        this.rootComponentFactory = rootComponentFactory;
+      }
+
+      this._resetError();
+      deepForceUpdate(this);
+    }
+
+    componentWillReceiveProps() {
+      this._resetError();
+      deepForceUpdate(this);
+    }
+
+    componentWillUnmount() {
+      instances[id] = instances[id].filter(instance => instance !== this);
+    }
+
+    componentDidCatch(error: Object) {
+      this.setState({
+        error,
+      });
+    }
+
+    render() {
+      if (this.state.error) {
+        console.error(this.state.error);
+        return null;
+      }
+
+      const Root = this.rootComponentFactory
+        ? this.rootComponentFactory()
+        : initialRootFactory();
+      return <Root {...this.props} />;
+    }
+  }
+
+  return () => hoistNonReactStatic(HotWrapper, initialRootFactory());
 }
 
 /**


### PR DESCRIPTION
This will fix the `makeHot` so it doesn't force-rerender every tiny little change that happens when used with routers.  It does this by not building a brand new component on every call of the resulting function. 

```javascript
const HotView = makeHot(() => HomeView, 'Home');
console.log(HotView() === HotView());
```

> Before the above would return false, therefore a re-render would be forced every time . `getScreen` is called by `react-navigation`

Note that this will still cause problems when utilized as documented since

```javascript
console.log(makeHot(() => HomeView, 'Home')() !== makeHot(() => HomeView, 'Home')())
```

Solution there would likely to use a `Map` of some sort to identify when we should return the previously created component instead of creating a new one.  Since I couldn't be 100% of the effects of doing this type of change I decided to at least make it fixable in the meantime. 

See #490 