### PR TITLE
Fix missing Webpack banner in release mode

### DIFF
--- a/src/utils/__tests__/__snapshots__/getConfig.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/getConfig.test.js.snap
@@ -180,6 +180,14 @@ Object {
         },
       },
     },
+    BannerPlugin {
+      "banner": [Function],
+      "options": Object {
+        "banner": "if (this && !this.self) { this.self = this; };
+",
+        "raw": true,
+      },
+    },
     HotModuleReplacementPlugin {
       "fullBuildTimeout": 200,
       "multiStep": undefined,
@@ -205,14 +213,6 @@ Object {
       "sourceMapFilename": "[file].map",
       "sourceMappingURLComment": "
 //# sourceMappingURL=[url]",
-    },
-    BannerPlugin {
-      "banner": [Function],
-      "options": Object {
-        "banner": "if (this && !this.self) { this.self = this; };
-",
-        "raw": true,
-      },
     },
   ],
   "resolve": Object {

--- a/src/utils/makeReactNativeConfig.js
+++ b/src/utils/makeReactNativeConfig.js
@@ -160,6 +160,10 @@ const getDefaultConfig = ({
         minimize: !!minify,
         debug: dev,
       }),
+      new webpack.BannerPlugin({
+        banner: 'if (this && !this.self) { this.self = this; };\n',
+        raw: true,
+      }),
     ].concat(
       dev
         ? [
@@ -172,10 +176,6 @@ const getDefaultConfig = ({
               test: /\.(js|css|(js)?bundle)($|\?)/i,
               filename: '[file].map',
             }),
-            new webpack.BannerPlugin({
-              banner: 'if (this && !this.self) { this.self = this; };\n',
-              raw: true,
-            }),
           ]
         : [
             /**
@@ -186,10 +186,6 @@ const getDefaultConfig = ({
             new webpack.SourceMapDevToolPlugin({
               test: /\.(js|css|(js)?bundle)($|\?)/i,
               filename: '[file].map',
-            }),
-            new webpack.BannerPlugin({
-              banner: 'if (this && !this.self) { this.self = this; };\n',
-              raw: true,
             }),
           ]
     ),

--- a/src/utils/makeReactNativeConfig.js
+++ b/src/utils/makeReactNativeConfig.js
@@ -187,6 +187,10 @@ const getDefaultConfig = ({
               test: /\.(js|css|(js)?bundle)($|\?)/i,
               filename: '[file].map',
             }),
+            new webpack.BannerPlugin({
+              banner: 'if (this && !this.self) { this.self = this; };\n',
+              raw: true,
+            }),
           ]
     ),
     resolve: {

--- a/src/utils/polyfillEnvironment.js
+++ b/src/utils/polyfillEnvironment.js
@@ -7,19 +7,6 @@
  */
 import { NativeModules } from 'react-native';
 
-// HACK:
-//   This is horrible.  I know.  But this hack seems to be needed due to the way
-//   React Native lazy evaluates `fetch` within `InitializeCore`.  This was fixed
-//   in 34-ish, but seems to be back again.  I hope I'm wrong because I lost sleep
-//   on this one.
-//
-//   Without this in place, global.fetch will be undefined and cause the symbolicate
-//   check to fail.  This must be something that the packager is doing that haul isn't.
-//   I also so people complaining about this in Jest as well.
-//
-// ref: https://github.com/callstack/haul/pull/74
-if (!global.self) global.self = global;
-
 require('../hot/client/importScriptsPolyfill');
 
 if (process.env.NODE_ENV !== 'production') {

--- a/src/utils/polyfillEnvironment.js
+++ b/src/utils/polyfillEnvironment.js
@@ -7,6 +7,19 @@
  */
 import { NativeModules } from 'react-native';
 
+// HACK:
+//   This is horrible.  I know.  But this hack seems to be needed due to the way
+//   React Native lazy evaluates `fetch` within `InitializeCore`.  This was fixed
+//   in 34-ish, but seems to be back again.  I hope I'm wrong because I lost sleep
+//   on this one.
+//
+//   Without this in place, global.fetch will be undefined and cause the symbolicate
+//   check to fail.  This must be something that the packager is doing that haul isn't.
+//   I also so people complaining about this in Jest as well.
+//
+// ref: https://github.com/callstack/haul/pull/74
+if (!global.self) global.self = global;
+
 require('../hot/client/importScriptsPolyfill');
 
 if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
This PR is a fix to the missing `fetch()` in release mode.
https://github.com/callstack/haul/issues/489