### PR TITLE
Do not transpile to commonjs to enable webpack tree shaking

### DIFF
--- a/src/utils/__tests__/__snapshots__/getBabelConfig.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/getBabelConfig.test.js.snap
@@ -8,7 +8,12 @@ Object {
     "<<REPLACED>>/src/hot/babelPlugin.js",
   ],
   "presets": Array [
-    "<<NODE_MODULE>>/metro-react-native-babel-preset/src/index.js",
+    Array [
+      "<<NODE_MODULE>>/metro-react-native-babel-preset/src/index.js",
+      Object {
+        "disableImportExportTransform": true,
+      },
+    ],
   ],
 }
 `;
@@ -19,7 +24,12 @@ Object {
     "<<REPLACED>>/src/utils/fixRequireIssues.js",
   ],
   "presets": Array [
-    "<<NODE_MODULE>>/metro-react-native-babel-preset/src/index.js",
+    Array [
+      "<<NODE_MODULE>>/metro-react-native-babel-preset/src/index.js",
+      Object {
+        "disableImportExportTransform": true,
+      },
+    ],
   ],
 }
 `;

--- a/src/utils/getBabelConfig.js
+++ b/src/utils/getBabelConfig.js
@@ -10,7 +10,12 @@ const path = require('path');
 const logger = require('../logger');
 
 const DEFAULT_BABELRC = {
-  presets: [require.resolve('metro-react-native-babel-preset')],
+  presets: [
+    [
+      require.resolve('metro-react-native-babel-preset'),
+      { disableImportExportTransform: true },
+    ],
+  ],
 };
 
 module.exports = function getBabelConfig(cwd: string) {


### PR DESCRIPTION
This PR enables webpack's tree shaking by not allowing babel to transform `import`/`export` statements to commonjs modules.

https://webpack.js.org/guides/tree-shaking/

**More info**
We noticed we were getting bigger bundles when using metro vs haul. We use webpack and tree shaking for our web bundles which greatly reduces their size.

Since haul uses webpack and webpack takes care of the `import` and `export` statements I think it would make sense to let webpack take care of this and do it's magic?

We enabled this same setting on our mobile bundle by using the custom `.babelrc` option and saw a significant reduction in size of 366 KB from 2.17 MB to 1.80 MB.

There might be a reason why you haven't done this already, but I couldn't find any info around it in the current issues. I worked pretty smoothly for us so I figured I'd create a PR :)