### PR TITLE
Fix: add @react-navigation to regex to include in transform

### DIFF
--- a/src/utils/__tests__/__snapshots__/getConfig.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/getConfig.test.js.snap
@@ -81,7 +81,7 @@ Object {
         },
       },
       Object {
-        "exclude": /node_modules\\(\\?!\\.\\*\\[\\\\/\\\\\\\\\\]\\(react\\|@expo\\|pretty-format\\|haul\\|metro\\)\\)/,
+        "exclude": /node_modules\\(\\?!\\.\\*\\[\\\\/\\\\\\\\\\]\\(react\\|@react-navigation\\|@expo\\|pretty-format\\|haul\\|metro\\)\\)/,
         "test": /\\\\\\.js\\$/,
         "use": Array [
           Object {

--- a/src/utils/makeReactNativeConfig.js
+++ b/src/utils/makeReactNativeConfig.js
@@ -97,7 +97,7 @@ const getDefaultConfig = ({
         {
           test: /\.js$/,
           // eslint-disable-next-line no-useless-escape
-          exclude: /node_modules(?!.*[\/\\](react|@expo|pretty-format|haul|metro))/,
+          exclude: /node_modules(?!.*[\/\\](react|@react-navigation|@expo|pretty-format|haul|metro))/,
           use: [
             {
               loader: require.resolve('cache-loader'),


### PR DESCRIPTION
Per @thymikee comment in https://github.com/callstack/haul/issues/502#issuecomment-443130976 - I added @react-navigation to the regex pattern and updated snapshots.  

I had to modify my webpack config when I updated a couple weeks ago, so this is a nice addition.