### PR TITLE
Update link to docs to point to the new docs

### DIFF
--- a/src/utils/makeReactNativeConfig.js
+++ b/src/utils/makeReactNativeConfig.js
@@ -324,7 +324,7 @@ function makeReactNativeConfig(
 
   if (isLegacy) {
     logger.warn(
-      'You using a deprecated style of the configuration. Please follow the docs for the upgrade. See https://github.com/callstack/haul/blob/master/docs/Configuration.md'
+      'You using a deprecated style of the configuration. Please follow the docs for the upgrade. See https://github.com/callstack/haul/blob/next/docs/Configuration.md'
     );
 
     return DEPRECATEDMakeReactNativeConfig(


### PR DESCRIPTION
Previously it was asking users to stop using the deprecated style of configuration while still pointing to docs for the deprecated style of configuration.

Might want to make a note to change this link back to `master` once `next` is merged into it.