### PR TITLE
whitelist modules with const variables (to work out of the box with react-navigation)

### DIFF
--- a/src/utils/makeReactNativeConfig.js
+++ b/src/utils/makeReactNativeConfig.js
@@ -97,7 +97,7 @@ const getDefaultConfig = ({
         {
           test: /\.js$/,
           // eslint-disable-next-line no-useless-escape
-          exclude: /node_modules(?!.*[\/\\](react|@react-navigation|@expo|pretty-format|haul|metro))/,
+          exclude: /node_modules(?!.*[\/\\](react|@react-navigation|query-string|strict-uri-encode|decode-uri-component|@expo|pretty-format|haul|metro))/,
           use: [
             {
               loader: require.resolve('cache-loader'),


### PR DESCRIPTION
fixes https://github.com/callstack/haul/issues/505 (also related to https://github.com/callstack/haul/issues/502)

these were the modules I had to whitelist to get react-navigation working on a fresh react-native project. 

i also noticed #503 has not been released either, would be great to get these fixes in (or at least add it to recipes) since react-navigation is the recommended navigation library.

 in case anyone encounters this, here's a config you can use:

```
  const jsRule = config.module.rules.find(rule => rule.test && rule.test.test('foo.js'))
  jsRule.exclude = /node_modules(?!.*[\/\\](react|@react-navigation|query-string|strict-uri-encode|decode-uri-component|pretty-format|haul|metro))/
  
```