### PR TITLE
Fixing temp directory path for assetDest

### DIFF
--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -64,7 +64,7 @@ async function start(opts: *) {
       ? opts.assetsDest
       : path.join(directory, opts.assetsDest);
   } else {
-    assetsDest = path.join(os.tmpdir(), fs.mkdtempSync('haul-start-'));
+    assetsDest = fs.mkdtempSync(path.join(os.tmpdir(), 'haul-start-'));
   }
 
   const configOptions = {


### PR DESCRIPTION
temp directory for assetDest was wrongly being created in project root, instead of `tmp`.

Fix for #519 