### PR TITLE
Add transpilation of @react-native-community

### DIFF
--- a/src/utils/__tests__/__snapshots__/getConfig.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/getConfig.test.js.snap
@@ -81,7 +81,7 @@ Object {
         },
       },
       Object {
-        "exclude": /node_modules\\(\\?!\\.\\*\\[\\\\/\\\\\\\\\\]\\(react\\|@react-navigation\\|@expo\\|pretty-format\\|haul\\|metro\\)\\)/,
+        "exclude": /node_modules\\(\\?!\\.\\*\\[\\\\/\\\\\\\\\\]\\(react\\|@react-navigation\\|@react-native-community\\|@expo\\|pretty-format\\|haul\\|metro\\)\\)/,
         "test": /\\\\\\.js\\$/,
         "use": Array [
           Object {

--- a/src/utils/makeReactNativeConfig.js
+++ b/src/utils/makeReactNativeConfig.js
@@ -99,7 +99,7 @@ const getDefaultConfig = ({
         {
           test: /\.js$/,
           // eslint-disable-next-line no-useless-escape
-          exclude: /node_modules(?!.*[\/\\](react|@react-navigation|@expo|pretty-format|haul|metro))/,
+          exclude: /node_modules(?!.*[\/\\](react|@react-navigation|@react-native-community|@expo|pretty-format|haul|metro))/,
           use: [
             {
               loader: require.resolve('cache-loader'),


### PR DESCRIPTION
### Summary

The new @react-native-community slider & asyncstorage libs for RN59 are shipped with flow types and require transpilation. This PR makes sure that all those libs are transpiled by default. This should typically not lead to any performance issues, as this code is almost always a small javascript interface to the native code. More of these libs will become available as part of the react-native lean code initiative.

### Solves

This solves these issues:

```
 ERROR  Failed to compile.

./node_modules/@react-native-community/slider/js/Slider.js 17:12
Module parse failed: Unexpected token (17:12)
You may need an appropriate loader to handle this file type.
| const RCTSliderNativeComponent = require('./RNCSliderNativeComponent');
|
> import type {NativeComponent} from 'react-native/Libraries/Renderer/shims/ReactNative';
| import type {ImageSource} from 'react-native/Libraries/Image/ImageSource';
| import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
@ ./src/components/slider/Slider.js 1:808-862 1:1793-1802
@ ./src/components/slider/index.js
@ ./src/components/index.js
@ ./src/screens/signIn/SignInWithEmailLinkScreen.js
@ ./src/screens/signIn/index.js
@ ./src/routing/Routes.js
@ ./src/routing/index.js
@ ./src/App.js
@ ./index.js
@ multi ./node_modules/haul/src/vendor/polyfills/Object.es6.js ./node_modules/haul/src/vendor/polyfills/console.js ./node_modules/haul/src/vendor/polyfills/error-guard.js ./node_modules/haul/src/vendor/polyfills/Number.es6.js ./node_modules/haul/src/vendor/polyfills/String.prototype.es6.js ./node_modules/haul/src/vendor/polyfills/Array.prototype.es6.js ./node_modules/haul/src/vendor/polyfills/Array.es6.js ./node_modules/haul/src/vendor/polyfills/Object.es7.js ./node_modules/haul/src/vendor/polyfills/babelHelpers.js ./node_modules/react-native/Libraries/Core/InitializeCore.js ./node_modules/haul/src/utils/polyfillEnvironment.js ./index.js

./node_modules/@react-native-community/async-storage/lib/AsyncStorage.js 24:5
Module parse failed: Unexpected token (24:5)
You may need an appropriate loader to handle this file type.
|   NativeModules.AsyncLocalStorage;
|
> type ReadOnlyArrayString = $ReadOnlyArray<string>;
|
| type MultiGetCallbackFunction = (
@ ./node_modules/@react-native-community/async-storage/lib/index.js 1:0-31 1:0-31
@ ./framework/auth/AuthModel.js
@ ./framework/auth/index.js
@ ./framework/index.js
@ ./src/App.js
@ ./index.js
@ multi ./node_modules/haul/src/vendor/polyfills/Object.es6.js ./node_modules/haul/src/vendor/polyfills/console.js ./node_modules/haul/src/vendor/polyfills/error-guard.js ./node_modules/haul/src/vendor/polyfills/Number.es6.js ./node_modules/haul/src/vendor/polyfills/String.prototype.es6.js ./node_modules/haul/src/vendor/polyfills/Array.prototype.es6.js ./node_modules/haul/src/vendor/polyfills/Array.es6.js ./node_modules/haul/src/vendor/polyfills/Object.es7.js ./node_modules/haul/src/vendor/polyfills/babelHelpers.js ./node_modules/react-native/Libraries/Core/InitializeCore.js ./node_modules/haul/src/utils/polyfillEnvironment.js ./index.js
```


### Test plan

- Create bare RN59 project
- install `@react-native-community/slider`
- Run haul