### PR TITLE
Avoid tripping Xcode's script error detection.

### DIFF
--- a/src/commands/bundle.js
+++ b/src/commands/bundle.js
@@ -214,7 +214,11 @@ let command = ({
       name: 'progress',
       description:
         'Display bundle compilation progress with different verbosity levels',
-      default: 'compact',
+      default: () => {
+        // Ensure that we don't trip Xcode's error detection. 'verbose' is the
+        // only level that doesn't make Xcode think that the bundle failed.
+        return !process.stdin.isTTY ? 'verbose' : 'compact';
+      },
       example: 'haul bundle --progress minimal',
       choices: [
         {


### PR DESCRIPTION
Xcode seems to fail if the verbosity level is set to anything other than `verbose`. Some of the characters used in the other levels makes Xcode think that errors have occurred. This was filed as #514 but was closed a bit early since there is a workaround.

### Summary

The patch detects whether we're in interactive mode and applies the correct verbosity level.

### Test plan

By default, without adding `--progress verbose` to the bundle command, Xcode should not fail.
