### PR TITLE
Mark asset path logs conditional on --verbose

### DIFF
--- a/src/loaders/assetLoader.js
+++ b/src/loaders/assetLoader.js
@@ -195,7 +195,9 @@ module.exports = async function assetLoader() {
   };
 
   try {
-    logger.info(`path: ${this.resourcePath}`);
+    if (isVerbose) {
+      logger.info(`path: ${this.resourcePath}`);
+    }
 
     info = size(this.resourcePath);
 


### PR DESCRIPTION
### Summary
When the asset loader evaluates the sizes of a new asset, it will also log the path to the asset. Whenever the logger outputs a new log line during a Webpack build, Webpack will repeat the following log line: `Webpack: Starting ...`. This PR adds makes the logging of the asset path conditional on the `--verbose` flag, similar to other log events in the same file.

Before:
```
Webpack: Starting ...

Webpack: Starting ...

Webpack: Starting ...

Webpack: Starting ...

Webpack: Starting ...

Webpack: Starting ...

Webpack: Starting ...

Webpack: Starting ...

Webpack: Starting ...

Webpack: Starting ...

Webpack: Starting ...

  √ Compile modules
  > Build modules (96%)
    → 1271 of 1322 modules :: [path]
```

After
```
Webpack: Starting ...

  √ Compile modules
  √ Compile modules
  √ Build modules
  √ Optimize modules
  √ Emit files
```

### Test plan
This change will only decrease the amount of log lines.