### PR TITLE
fix: use correct global when evaluating modules in RAM bundle on Android

### DIFF
--- a/packages/haul-ram-bundle-webpack-plugin/runtime/bootstrap.js
+++ b/packages/haul-ram-bundle-webpack-plugin/runtime/bootstrap.js
@@ -51,7 +51,7 @@ function bootstraper(globalScope, mainId, moduleMappings) { // eslint-disable-li
       throw new Error(moduleId + ' missing in module cache');
     }
     var module = installedModules[moduleId];
-    factory.call(module.exports, module, module.exports, __webpack_require__);
+    factory.call(globalScope, module, module.exports, __webpack_require__);
 
     // Flag the module as loaded
     module.l = true;


### PR DESCRIPTION
https://github.com/callstack/haul/projects/2#card-21226745