### PR TITLE
Update assertLoader correct path

### DIFF
--- a/packages/haul-core/src/constants.ts
+++ b/packages/haul-core/src/constants.ts
@@ -3,4 +3,7 @@ import { join } from 'path';
 export const INTERACTIVE_MODE_DEFAULT = true;
 export const DEFAULT_CONFIG_FILENAME = 'haul.config.js';
 export const DEFAULT_PORT = 8081;
-export const ASSET_LOADER_PATH = join(__dirname, './webpack/loaders/assetLoader');
+export const ASSET_LOADER_PATH = join(
+  __dirname,
+  './webpack/loaders/assetLoader'
+);

--- a/packages/haul-core/src/constants.ts
+++ b/packages/haul-core/src/constants.ts
@@ -3,4 +3,4 @@ import { join } from 'path';
 export const INTERACTIVE_MODE_DEFAULT = true;
 export const DEFAULT_CONFIG_FILENAME = 'haul.config.js';
 export const DEFAULT_PORT = 8081;
-export const ASSET_LOADER_PATH = join(__dirname, './loaders/assetLoader');
+export const ASSET_LOADER_PATH = join(__dirname, './webpack/loaders/assetLoader');


### PR DESCRIPTION
When trying to bundle I'm getting the error:
ModuleNotFoundError: Module not found: Error: Can't resolve '<path>/node_modules/@haul-bundler/core/build/loaders/assetLoader' in '<path>'

the right path is  '<path>/node_modules/@haul-bundler/core/build/webpack/loaders/assetLoader'