### PR TITLE
[FEAT] support asset regex

### DIFF
--- a/fixtures/exampleApp_0_59x/.gitignore
+++ b/fixtures/exampleApp_0_59x/.gitignore
@@ -54,6 +54,8 @@ buck-out/
 
 # Bundle artifact
 *.jsbundle
+*.bundle
+js-modules/
 
 # Haul
 #

--- a/fixtures/exampleApp_0_59x/haul.config.js
+++ b/fixtures/exampleApp_0_59x/haul.config.js
@@ -22,6 +22,9 @@ export default {
   //     path: 'ram_bundle',
   //     renderBootstrap: true,
   //     renderModules: true,
+  //   },
+  //   assetRegex: {
+  //     ps: /assets\//,
   //   }
   // }
 };

--- a/packages/haul-core/src/config/types.ts
+++ b/packages/haul-core/src/config/types.ts
@@ -38,6 +38,9 @@ export type RamBundleDebugOptions = {
 
 export type RamBundleConfig = {
   debug?: RamBundleDebugOptions;
+  assetRegex?: {
+    [platform: string]: RegExp | undefined;
+  };
   minification?: { enabled: boolean } & Pick<
     MinifyOptions,
     Exclude<keyof MinifyOptions, 'sourceMap'>

--- a/packages/haul-ram-bundle-webpack-plugin/README.md
+++ b/packages/haul-ram-bundle-webpack-plugin/README.md
@@ -26,6 +26,9 @@ type RamBundleDebugOptions = {
 
 type RamBundleConfig = {
   debug?: RamBundleDebugOptions;
+  assetRegex?: {
+    [platform: string]: RegExp | undefined;
+  };
   minification?: { enabled: boolean } & Pick<
     MinifyOptions, // Terser minify options
     Exclude<keyof MinifyOptions, 'sourceMap'>
@@ -34,6 +37,8 @@ type RamBundleConfig = {
 
 new WebpackRamBundlePlugin({
   sourceMap: true, // whether to generate source maps
+  indexRamBundle: true, // whether to build Indexed RAM bundle or File RAM bundle
+  platform: 'ios',
   config: { // RamBundleConfig
     minification: {
       enabled: true, // whether to minify the source code
@@ -41,6 +46,39 @@ new WebpackRamBundlePlugin({
     },
   },
 });
+```
+
+### Support for out-of-tree platforms
+
+By default `@haul-bundler/ram-bundle-webpack-plugin` supports `ios` and `android` platforms. To add support for other platform, use `assetRegex` option together with `platform`:
+
+```ts
+new WebpackRamBundlePlugin({
+  indexRamBundle: true, // use Indexed RAM bundle
+  platform: 'my-platform',
+  config: { // RamBundleConfig
+    assetRegex: {
+      'my-platform': /resources\//, // regex for where assets for 'my-platform' will be
+    },
+  },
+});
+```
+
+If you are using the plugin with `@haul-bundler/cli`, you can specify `assetRegex` option in `haul.config.js`:
+
+```js
+import { createWebpackConfig } from "@haul-bundler/preset-0.59";
+
+export default {
+  webpack: createWebpackConfig(({ platform }) => ({
+    entry: `./index.js`
+  })),
+  ramBundle: {
+    assetRegex: {
+      'my-platform': /resources\//,
+    }
+  }
+};
 ```
 
 <!-- badges (common) -->

--- a/packages/haul-ram-bundle-webpack-plugin/src/WebpackRamBundlePlugin.ts
+++ b/packages/haul-ram-bundle-webpack-plugin/src/WebpackRamBundlePlugin.ts
@@ -213,6 +213,7 @@ export default class WebpackRamBundlePlugin {
         const assetRegex = ({
           ios: /assets\//,
           android: /drawable-.+\//,
+          ...(this.config.assetRegex || {}),
         } as { [key: string]: RegExp | undefined })[this.platform];
 
         if (!assetRegex) {

--- a/packages/haul-ram-bundle-webpack-plugin/src/WebpackRamBundlePlugin.ts
+++ b/packages/haul-ram-bundle-webpack-plugin/src/WebpackRamBundlePlugin.ts
@@ -213,7 +213,7 @@ export default class WebpackRamBundlePlugin {
         const assetRegex = ({
           ios: /assets\//,
           android: /drawable-.+\//,
-          ...(this.config.assetRegex || {}),
+          ...this.config.assetRegex,
         } as { [key: string]: RegExp | undefined })[this.platform];
 
         if (!assetRegex) {


### PR DESCRIPTION
Support asset regex in RAMBundle config:
`haul.config.js`:
```js
{
  ramBundle: {
    assetRegex: {
      ios: /assets\//,
      otherPlatform: /regex\//
    }
  }
}
```