### PR TITLE
fix: forward watchOptions to fs watcher.

### DIFF
--- a/packages/haul-core-legacy/src/compiler/worker/runWebpackCompiler.js
+++ b/packages/haul-core-legacy/src/compiler/worker/runWebpackCompiler.js
@@ -94,7 +94,7 @@ module.exports = function runWebpackCompiler({
   });
 
   emitter.on('start', () => {
-    compiler.watch({}, () => {});
+    compiler.watch(config.watchOptions || {}, () => {});
     emitter.emit(Events.BUILD_START);
   });
 


### PR DESCRIPTION
`watchOptions` is not correctly forwarded to webpack's watcher.

### Summary

It is currently not possible to set [`watchOptions`](https://webpack.js.org/configuration/watch/#watchoptions). With this fix, it will be correctly forwarded.

### Test plan

Add the following lines (or similar) to `haul.config.js`:

```js
  watchOptions: {
    ignored: /.*\.tsx?$/
  }
```

When you touch a `.ts`/`.tsx` file, Haul shouldn't recompile.