### PR TITLE
fix: transpile async/await in `haul-bundler/babel-preset-react-native`

### DIFF
--- a/packages/haul-babel-preset-react-native/package.json
+++ b/packages/haul-babel-preset-react-native/package.json
@@ -32,6 +32,7 @@
     "@babel/plugin-transform-sticky-regex": "^7.2.0",
     "@babel/plugin-transform-typescript": "^7.4.4",
     "@babel/plugin-transform-unicode-regex": "^7.4.4",
+    "babel-plugin-transform-async-to-promises": "^0.8.11",
     "metro-react-native-babel-preset": "^0.54.0"
   }
 }

--- a/packages/haul-babel-preset-react-native/src/index.ts
+++ b/packages/haul-babel-preset-react-native/src/index.ts
@@ -6,6 +6,10 @@ const defaultPlugins = [
   [require('@babel/plugin-transform-react-jsx')],
   [require('@babel/plugin-transform-sticky-regex')],
   [require('@babel/plugin-transform-unicode-regex')],
+  // For some reason native async/await don't behave correctly
+  // on RN 0.59 on both platforms, so we need to transpile it
+  // to native Promises.
+  [require('babel-plugin-transform-async-to-promises')],
   [
     require('@babel/plugin-transform-modules-commonjs'),
     { allowTopLevelThis: true },
@@ -25,8 +29,7 @@ export default function getHaulBabelPreset() {
     comments: false,
     compact: true,
     overrides: [
-      // the flow strip types plugin must go BEFORE class properties!
-      // there'll be a test case that fails if you don't.
+      // The flow strip types plugin must go BEFORE class properties!
       {
         plugins: [require('@babel/plugin-transform-flow-strip-types')],
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3308,6 +3308,11 @@ babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz#aa213c1435e2bffeb6fca842287ef534ad05d5cf"
   integrity sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==
 
+babel-plugin-transform-async-to-promises@^0.8.11:
+  version "0.8.11"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-promises/-/babel-plugin-transform-async-to-promises-0.8.11.tgz#30b145149e34cbb06cc3b06179ef0a8f70dd1b5c"
+  integrity sha512-Ut0In27GXx//Z3Gw8nhfg4pse7U4rd0t46oAvdvOWPCPSkEAemH1d6lIOFQb+oDdv70hIM+B7vOtLUP6dNdSiA==
+
 babel-preset-fbjs@^3.0.1, babel-preset-fbjs@^3.1.2, babel-preset-fbjs@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/babel-preset-fbjs/-/babel-preset-fbjs-3.2.0.tgz#c0e6347d3e0379ed84b3c2434d3467567aa05297"


### PR DESCRIPTION
Native async/await behave incorrectly on RN 0.59 on both platforms and they not always resolve or resolve under certain conditions.