### PR TITLE
Fix /open-stack-frame validation

### DIFF
--- a/packages/haul-core/src/server/setupDevtoolRoutes.ts
+++ b/packages/haul-core/src/server/setupDevtoolRoutes.ts
@@ -36,6 +36,7 @@ export default function setupDevtoolRoutes(
           file: Joi.string().required(),
           lineNumber: Joi.number().required(),
           column: Joi.number().required(),
+          methodName: Joi.string().required(),
         },
       },
     },


### PR DESCRIPTION
### Summary

React Native is sending a methodName in the payload that fails validation.

### Test plan

To reproduce, throw an exception somewhere in your React Native app. From the error screen, tap in one of the stack frames. Haul's log before this would show `POST /open-stack-frame 400` and do nothing.

After this change, it should open your editor in the file referenced in the stack frame.
