### PR TITLE
docs: add note about localhost/0.0.0.0 issue

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -52,8 +52,9 @@ Project configuration object (the one accepted by `makeConfig` function) consist
 
 - `server?: ServerConfig` (_optional_) - Specify custom port and host for the packager server:
   - `host?: string` (_optional_) - Host to use for the packager server, defaults to `localhost`.
+    - Note: if you are having trouble connecting to the development server with `localhost` try `'0.0.0.0'`
   - `port?: number` (_optional_) - Port to use for the packager server, defaults to `8081`.
-- `platforms?: string[]` (_optional_) - List of supported platforms - useful for defining out-of-tree platforms.  
+- `platforms?: string[]` (_optional_) - List of supported platforms - useful for defining out-of-tree platforms.
   Defaults to `['ios', 'android']`.
 
   When providing the value, you need to specify all of the available platforms, for example to **add** `windows` your need to pass `['windows', 'ios', 'android']`.


### PR DESCRIPTION
This commit updates the Configuration doc to include a note about
configuring the server to use host '0.0.0.0' if there is an issue
connecting to the dev server on localhost.

I experienced an issue where my react native app running on a ios device
could not connect to the development server when using the default
(localhost) server configuration. Changing the host to 0.0.0.0 fixed the
issue for me so others might find that advice useful as well.


### Summary

This pull request just adds a note to the docs that might help people solve issues connecting to the dev server from a device. 

### Test plan

n/a: docs only change
