### PR TITLE
fix: Speed up source map generation by only stringiying at the end

### DIFF
--- a/packages/haul-ram-bundle-webpack-plugin/src/IndexRamBundle.ts
+++ b/packages/haul-ram-bundle-webpack-plugin/src/IndexRamBundle.ts
@@ -114,11 +114,10 @@ export default class IndexRamBundle {
         });
 
         lineOffset += countLines(sourceModule.source);
-
-        compilation.assets[sourceMapFilename] = new RawSource(
-          JSON.stringify(indexMap)
-        );
       });
+      compilation.assets[sourceMapFilename] = new RawSource(
+        JSON.stringify(indexMap)
+      );
     }
   }
 }


### PR DESCRIPTION
Currently when generating source maps, we stringiyf the in-progress
indexMap once for every. single. file. even though we only care about
the final result (and indeed overwrite our previous stringification each
file). This was likely a typo and intended to be outside the forEach, so
this change moves the stringification to after we're fully done building
up the indexMap. This dramatically speeds up source map generation since
we're doing significantly less work with fewer allocations and GCs.