### PR TITLE
fix: inline source maps for TS + split source w/ and w/o maps

### DIFF
--- a/packages/haul-core/src/preset/__tests__/__snapshots__/makeConfigFactory.test.ts.snap
+++ b/packages/haul-core/src/preset/__tests__/__snapshots__/makeConfigFactory.test.ts.snap
@@ -128,7 +128,7 @@ Object {
             "filename": "[file].map",
             "module": true,
             "moduleFilenameTemplate": "[absolute-resource-path]",
-            "test": /\\\\\\.\\(js\\|css\\|\\(js\\)\\?bundle\\)\\(\\$\\|\\\\\\?\\)/i,
+            "test": /\\\\\\.\\(js\\|jsx\\|css\\|ts\\|tsx\\|\\(js\\)\\?bundle\\)\\(\\$\\|\\\\\\?\\)/i,
           },
           "sourceMapFilename": "[file].map",
           "sourceMappingURLComment": "
@@ -198,7 +198,7 @@ Object {
             "filename": "[file].map",
             "module": true,
             "moduleFilenameTemplate": "[absolute-resource-path]",
-            "test": /\\\\\\.\\(js\\|css\\|\\(js\\)\\?bundle\\)\\(\\$\\|\\\\\\?\\)/i,
+            "test": /\\\\\\.\\(js\\|jsx\\|css\\|ts\\|tsx\\|\\(js\\)\\?bundle\\)\\(\\$\\|\\\\\\?\\)/i,
           },
           "sourceMapFilename": "[file].map",
           "sourceMappingURLComment": "
@@ -263,7 +263,7 @@ Object {
             "filename": "[file].map",
             "module": true,
             "moduleFilenameTemplate": "[absolute-resource-path]",
-            "test": /\\\\\\.\\(js\\|css\\|\\(js\\)\\?bundle\\)\\(\\$\\|\\\\\\?\\)/i,
+            "test": /\\\\\\.\\(js\\|jsx\\|css\\|ts\\|tsx\\|\\(js\\)\\?bundle\\)\\(\\$\\|\\\\\\?\\)/i,
           },
           "sourceMapFilename": "[file].map",
           "sourceMappingURLComment": "
@@ -418,7 +418,7 @@ Object {
             "filename": "[file].map",
             "module": true,
             "moduleFilenameTemplate": "[absolute-resource-path]",
-            "test": /\\\\\\.\\(js\\|css\\|\\(js\\)\\?bundle\\)\\(\\$\\|\\\\\\?\\)/i,
+            "test": /\\\\\\.\\(js\\|jsx\\|css\\|ts\\|tsx\\|\\(js\\)\\?bundle\\)\\(\\$\\|\\\\\\?\\)/i,
           },
           "sourceMapFilename": "[file].map",
           "sourceMappingURLComment": "
@@ -482,7 +482,7 @@ Object {
             "filename": "[file].map",
             "module": true,
             "moduleFilenameTemplate": "[absolute-resource-path]",
-            "test": /\\\\\\.\\(js\\|css\\|\\(js\\)\\?bundle\\)\\(\\$\\|\\\\\\?\\)/i,
+            "test": /\\\\\\.\\(js\\|jsx\\|css\\|ts\\|tsx\\|\\(js\\)\\?bundle\\)\\(\\$\\|\\\\\\?\\)/i,
           },
           "sourceMapFilename": "[file].map",
           "sourceMappingURLComment": "
@@ -541,7 +541,7 @@ Object {
             "filename": "[file].map",
             "module": true,
             "moduleFilenameTemplate": "[absolute-resource-path]",
-            "test": /\\\\\\.\\(js\\|css\\|\\(js\\)\\?bundle\\)\\(\\$\\|\\\\\\?\\)/i,
+            "test": /\\\\\\.\\(js\\|jsx\\|css\\|ts\\|tsx\\|\\(js\\)\\?bundle\\)\\(\\$\\|\\\\\\?\\)/i,
           },
           "sourceMapFilename": "[file].map",
           "sourceMappingURLComment": "
@@ -648,7 +648,7 @@ Object {
             "filename": "[file].map",
             "module": true,
             "moduleFilenameTemplate": "[absolute-resource-path]",
-            "test": /\\\\\\.\\(js\\|css\\|\\(js\\)\\?bundle\\)\\(\\$\\|\\\\\\?\\)/i,
+            "test": /\\\\\\.\\(js\\|jsx\\|css\\|ts\\|tsx\\|\\(js\\)\\?bundle\\)\\(\\$\\|\\\\\\?\\)/i,
           },
           "sourceMapFilename": "[file].map",
           "sourceMappingURLComment": "

--- a/packages/haul-core/src/preset/utils/getSourceMapPlugin.ts
+++ b/packages/haul-core/src/preset/utils/getSourceMapPlugin.ts
@@ -9,9 +9,7 @@ export default function getSourceMapPlugin(
   serverConfig: NormalizedServerConfig
 ) {
   const baseOptions = {
-    test: /\.(js|css|(js)?bundle)($|\?)/i,
-    filename: '[file].map',
-    moduleFilenameTemplate: '[absolute-resource-path]',
+    test: /\.(js|jsx|css|ts|tsx|(js)?bundle)($|\?)/i,
     module: true,
   };
 
@@ -21,7 +19,11 @@ export default function getSourceMapPlugin(
       publicPath: `http://${serverConfig.host}:${serverConfig.port}/`,
     } as webpack.EvalSourceMapDevToolPluginOptions);
   } else if (bundleConfig.sourceMap) {
-    return new webpack.SourceMapDevToolPlugin(baseOptions);
+    return new webpack.SourceMapDevToolPlugin({
+      ...baseOptions,
+      filename: '[file].map',
+      moduleFilenameTemplate: '[absolute-resource-path]',
+    });
   }
 
   return undefined;


### PR DESCRIPTION
- Generate inline source maps for `.ts`/`.tsx` files.
- Split source with inline source maps and without into separate groups - `webpack://` and `webpack-internal://` for better visibility of sources with maps


<img width="246" alt="Screenshot 2019-08-12 at 13 13 44" src="https://user-images.githubusercontent.com/17573635/62863143-3fd7b500-bd08-11e9-8bc2-4180e1952dde.png">
<img width="517" alt="Screenshot 2019-08-12 at 13 13 52" src="https://user-images.githubusercontent.com/17573635/62863144-3fd7b500-bd08-11e9-9d76-7490e477d23b.png">
