### PR TITLE
Reads ANDROID_HOME for adb location

### DIFF
--- a/packages/haul-core/src/utils/runAdbReverse.ts
+++ b/packages/haul-core/src/utils/runAdbReverse.ts
@@ -5,7 +5,9 @@ export default function runAdbReverse(
   runtime: Runtime,
   port: number
 ): Promise<string | undefined> {
-  const command = `adb reverse tcp:${port} tcp:${port}`;
+  const androidHome = process.env.ANDROID_HOME;
+  const adb = androidHome ? `${androidHome}/platform-tools/adb` : 'adb';
+  const command = `${adb} reverse tcp:${port} tcp:${port}`;
 
   return new Promise(resolve => {
     exec(command, error => {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
The ANDROID_HOME environment variable defines where to find platform tools like adb, and occasionally (my setup), these aren't in the global system PATH. This explicitly uses the path to access adb instead of relying on it being in the system PATH.

### Test plan
No tests needed AFAIK - unless there is coverage here that I don't know about.
