### PR TITLE
fix: only add plugin-transform-react-jsx-source in dev

### DIFF
--- a/packages/haul-babel-preset-react-native/src/index.ts
+++ b/packages/haul-babel-preset-react-native/src/index.ts
@@ -100,8 +100,10 @@ export default function getHaulBabelPreset(
             },
           ],
           require('@babel/plugin-transform-react-display-name'),
-          require('@babel/plugin-transform-react-jsx-source'),
           require('metro-react-native-babel-preset/src/transforms/transform-symbol-member'),
+          ...(process.env.NODE_ENV === 'production'
+            ? []
+            : [require('@babel/plugin-transform-react-jsx-source')]),
         ],
       },
     ],

--- a/packages/haul-babel-preset-react-native/src/index.ts
+++ b/packages/haul-babel-preset-react-native/src/index.ts
@@ -101,7 +101,8 @@ export default function getHaulBabelPreset(
           ],
           require('@babel/plugin-transform-react-display-name'),
           require('metro-react-native-babel-preset/src/transforms/transform-symbol-member'),
-          ...(process.env.NODE_ENV === 'production'
+          ...(process.env.BABEL_ENV === 'production' ||
+          process.env.NODE_ENV === 'production'
             ? []
             : [require('@babel/plugin-transform-react-jsx-source')]),
         ],


### PR DESCRIPTION
### Summary

Conditionally add `@babel/plugin-transform-react-jsx-source` so we don't get `__source` injected into production bundles, and reduce the bundle size.

### Test plan

All current tests should pass.
