### PR TITLE
feat: Use supplied packager host

### DIFF
--- a/packages/haul-core/assets/debuggerWorker.js
+++ b/packages/haul-core/assets/debuggerWorker.js
@@ -119,8 +119,10 @@ class DebuggerWorker {
     this.shouldQueueMessages = true;
 
     let error;
+    const scriptURL = new URL(message.url);
+    scriptURL.host = self.location.host;
     try {
-      importScripts(message.url)
+      importScripts(scriptURL.href);
     } catch (e) {
       error = e;
       if (self.ErrorUtils) {

--- a/packages/haul-core/src/server/setupDevtoolRoutes.ts
+++ b/packages/haul-core/src/server/setupDevtoolRoutes.ts
@@ -7,6 +7,16 @@ import Runtime from '../runtime/Runtime';
 import openInEditor from './openInEditor';
 import { promisify } from 'util';
 
+const defaultAndroidEmulatorHostnames: string[] = ['10.0.2.2', '10.0.3.2'];
+
+// If no debug_http_host is set, use localhost as the hostname.
+// The iOS Simulator will use localhost as a default.
+function getHostname(hostname: string): string {
+  return defaultAndroidEmulatorHostnames.includes(hostname)
+    ? 'localhost'
+    : hostname;
+}
+
 export default function setupDevtoolRoutes(
   runtime: Runtime,
   server: Hapi.Server,
@@ -17,10 +27,11 @@ export default function setupDevtoolRoutes(
     path: '/launch-js-devtools',
     handler: request => {
       // Open debugger page only if it's not already open.
+      const host = getHostname(request.url.hostname);
       if (!isDebuggerConnected()) {
         launchBrowser(
           runtime,
-          `http://localhost:${request.raw.req.socket.localPort}/debugger-ui`
+          `http://${host}:${request.url.port}/debugger-ui`
         );
       }
       return 'OK';


### PR DESCRIPTION
This enables support for supplying the packager host by using
debug_http_host on Android or by changing bundleURL in
RCTWebSocketExecutor.m on iOS.

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
It is now possible to run an application on more than Device/Emulator, as one is not dependent anymore on `adb reverse` (on Android), when the host machine's IP address is used.

The supplied host (for example the host's machine IP address) is then used to open the debugger on the correct URL (instead of the previous hardcoded `localhost`).
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

1. Edit `haul.config.js` in the `react_native_with_haul` and add a server config with a custom host and port.
2. 
- For Android: Add the following in `MainApplication.java:onCreate`
```java
PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).edit()
  .putString("debug_http_host", String.format("%s:%s", yourHostname, yourPort)).apply();
```
   - For iOS: Set the host and port in `RCTWebSocketExecutor.m`
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
3. Run `npm start`

The applications' bundles should now load correctly on both Android and iOS. The remote debugging site should open on the correct URL and the debugging itself should also work.

It should also be possible to run the application on multiple Devices and Emulators simultaneously, with a working remote debugger.
