### PR TITLE
fix: transform spread operator for Hermes

### DIFF
--- a/packages/haul-babel-preset-react-native/src/index.ts
+++ b/packages/haul-babel-preset-react-native/src/index.ts
@@ -53,8 +53,10 @@ export function getDefaultPostPlugins(): PluginSpec[] {
 export function getHermesPlugins(): PluginSpec[] {
   // Additional plugins for Hermes because it doesn't support ES6 yet
   return [
-    ['@babel/plugin-transform-classes'],
     ['@babel/plugin-transform-shorthand-properties'],
+    ['@babel/plugin-transform-classes'],
+    ['@babel/plugin-transform-spread'],
+    ['@babel/plugin-proposal-object-rest-spread'],
     ['@babel/plugin-transform-template-literals', { loose: true }],
   ];
 }


### PR DESCRIPTION
### Summary

Hermes doesn't support spread operator. Added the necessary plugins to transform them to ES5 syntax.

### Test plan

All tests should pass.