### PR TITLE
fix: assign location.host only if self is available in debuggerWorker.js

### DIFF
--- a/packages/haul-core/assets/debuggerWorker.js
+++ b/packages/haul-core/assets/debuggerWorker.js
@@ -120,7 +120,10 @@ class DebuggerWorker {
 
     let error;
     const scriptURL = new URL(message.url);
-    scriptURL.host = self.location.host;
+    if (typeof self !== 'undefined' && self.location) {
+      scriptURL.host = self.location.host;
+    }
+   
     try {
       importScripts(scriptURL.href);
     } catch (e) {


### PR DESCRIPTION
#678 