### PR TITLE
fix: use rimraf for clean script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint --ext '.js,.ts' './packages'",
     "test": "jest",
-    "clean": "rm -rf ./packages/*/build ./packages/*/tsconfig.tsbuildinfo",
+    "clean": "rimraf ./packages/*/build ./packages/*/tsconfig.tsbuildinfo",
     "watch": "yarn clean && concurrently \"yarn:watch:source\" \"yarn:watch:ts\"",
     "build:source": "lerna exec --parallel \"babel src --out-dir build --extensions .js,.ts,.tsx --source-maps --config-file=../../babel.config.js\"",
     "watch:source": "lerna exec --parallel \"babel src --out-dir build --extensions .js,.ts,.tsx --source-maps --config-file=../../babel.config.js --watch\"",


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

On Windows, initial clone+yarn will end up with:
```
yarn install v1.17.3
[1/4] Resolving packages...
success Already up-to-date.
$ yarn clean && yarn build:source && yarn build:ts
yarn run v1.17.3
$ rm -rf ./packages/*/build ./packages/*/tsconfig.tsbuildinfo
'rm' is not recognized as an internal or external command,
operable program or batch file.
error Command failed with exit code 1.
```

This PR uses `rimraf` package to perform clean script in a cross-platform way.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
