### PR TITLE
fix: default value type for --skip-host-check

### DIFF
--- a/packages/haul-cli/src/commands/start.ts
+++ b/packages/haul-cli/src/commands/start.ts
@@ -55,7 +55,7 @@ export default function startCommand(runtime: Runtime) {
       },
       'skip-host-check': {
         description: 'Skips check for "index" or "host" bundle in Haul config',
-        default: 'false',
+        default: false,
         type: 'boolean',
       },
       'max-workers': {


### PR DESCRIPTION
### Summary

Earlier addition of `--skip-host-check` flag set its default value to a string `'false'` instead of boolean `false`, causing it to be incorrectly true-y by default.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
