### PR TITLE
feat: support additional hapi plugin for dev web server

### DIFF
--- a/packages/haul-cli/src/commands/start.ts
+++ b/packages/haul-cli/src/commands/start.ts
@@ -158,6 +158,7 @@ export default function startCommand(runtime: Runtime) {
           platforms: projectConfig.platforms,
           bundleNames: Object.keys(projectConfig.bundles),
           skipHostCheck: argv.skipHostCheck,
+          plugins: projectConfig.server.plugins,
         }).listen(projectConfig.server.host, projectConfig.server.port);
       } catch (error) {
         runtime.logger.error('Command failed with error:', error);

--- a/packages/haul-core/src/config/types.ts
+++ b/packages/haul-core/src/config/types.ts
@@ -2,7 +2,7 @@ import webpack from 'webpack';
 import { MinifyOptions } from 'terser';
 import { DeepNonNullable, Overwrite, Assign } from 'utility-types';
 import Runtime from '../runtime/Runtime';
-import { ServerRegisterOptions, ServerRegisterPluginObject } from '@hapi/hapi';
+import { ServerRegisterPluginObject } from '@hapi/hapi';
 
 export type ServerConfig = {
   port?: number;

--- a/packages/haul-core/src/config/types.ts
+++ b/packages/haul-core/src/config/types.ts
@@ -2,10 +2,12 @@ import webpack from 'webpack';
 import { MinifyOptions } from 'terser';
 import { DeepNonNullable, Overwrite, Assign } from 'utility-types';
 import Runtime from '../runtime/Runtime';
+import { ServerRegisterOptions, ServerRegisterPluginObject } from '@hapi/hapi';
 
 export type ServerConfig = {
   port?: number;
   host?: string;
+  plugins?: Array<ServerRegisterPluginObject<any>>;
 };
 
 export type NormalizedServerConfig = DeepNonNullable<ServerConfig>;

--- a/packages/haul-core/src/server/Server.ts
+++ b/packages/haul-core/src/server/Server.ts
@@ -1,6 +1,10 @@
 import { EnvOptions } from '../config/types';
 import { Assign } from 'utility-types';
-import Hapi, { ResponseObject } from '@hapi/hapi';
+import Hapi, {
+  ResponseObject,
+  ServerRegisterOptions,
+  ServerRegisterPluginObject,
+} from '@hapi/hapi';
 import http from 'http';
 import ws from 'ws';
 // @ts-ignore
@@ -27,6 +31,7 @@ type ServerEnvOptions = Assign<
     bundleNames: string[];
     platforms: string[];
     skipHostCheck: boolean;
+    plugins?: Array<ServerRegisterPluginObject<any>>;
   }
 >;
 
@@ -179,6 +184,9 @@ export default class Server {
       webSocketProxy
     );
 
+    if (Array.isArray(this.options.plugins)) {
+      await server.register(this.options.plugins);
+    }
     await server.register(require('@hapi/inert'));
 
     server.events.on('response', request => {
@@ -190,7 +198,6 @@ export default class Server {
         }
       }
     });
-
     setupSymbolication(this.runtime, server, {
       bundleNames: this.options.bundleNames,
     });


### PR DESCRIPTION
### Summary

Some plugins of hapi may be used during the development process, such as proxy server, mock server...

### Test plan

Just expose a passthrough option called `plugins` within project configuration's `server` field.
