### PR TITLE
fix: Support user-defined platforms when serving

### DIFF
--- a/packages/haul-core/src/server/setupCompilerRoutes.ts
+++ b/packages/haul-core/src/server/setupCompilerRoutes.ts
@@ -33,10 +33,12 @@ export default function setupCompilerRoutes(
   let hasRunAdbReverse = false;
   let hasWarnedDelta = false;
   const bundleRegex = /^([^.]+)(\.[^.]+)?\.(bundle|delta)$/;
-  let bundleOptions: PlatformsBundleOptions = {
-    ios: { ...cliBundleOptions },
-    android: { ...cliBundleOptions },
-  };
+  let bundleOptions: PlatformsBundleOptions = platforms.reduce<
+    PlatformsBundleOptions
+  >((options, platform) => {
+    options[platform] = { ...cliBundleOptions };
+    return options;
+  }, {});
 
   server.route({
     method: 'GET',


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

#729 breaks react-native-windows projects, as it omits platforms other than `ios` and `android`:
```
done ▶︎ Packager server running on http://localhost:8081
info ▶︎ Chrome Remote debugger connected
info ▶︎ GET /launch-js-devtools 200
info ▶︎ React Native debugger client connected
info ▶︎ Compiling bundle "index" for platform windows
error ▶︎ Debug: internal, implementation, error
TypeError: Cannot read property 'alreadySet' of undefined
at isUserChangedAlreadySetBundleOptions
(D:\playground\HaulRepro\node_modules\@haul-bundler\core\build\server\setupCompilerRoutes.js:191:23)
at handler (D:\playground\HaulRepro\node_modules\@haul-bundler\core\build\server\setupCompilerRoutes.js:93:38)
at module.exports.internals.Manager.execute (D:\playground\HaulRepro\node_modules\@hapi\hapi\lib\toolkit.js:41:33)
at Object.internals.handler (D:\playground\HaulRepro\node_modules\@hapi\hapi\lib\handler.js:46:48)
at exports.execute (D:\playground\HaulRepro\node_modules\@hapi\hapi\lib\handler.js:31:36)
at Request._lifecycle (D:\playground\HaulRepro\node_modules\@hapi\hapi\lib\request.js:312:68)
at processTicksAndRejections (internal/process/task_queues.js:93:5)
at async Request._execute (D:\playground\HaulRepro\node_modules\@hapi\hapi\lib\request.js:221:9)
error ▶︎ GET /index.bundle 500
```

This PR initializes `bundleOptions` properly with all platforms provided.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
