### PR TITLE
fix: Fix incorrect sourcemap overwrite during transform

### DIFF
--- a/packages/haul-core/src/webpack/loaders/babelWorkerLoader/vendor/transform.ts
+++ b/packages/haul-core/src/webpack/loaders/babelWorkerLoader/vendor/transform.ts
@@ -20,7 +20,7 @@ export default async function(
 
   const { ast, code, map, metadata, sourceType } = result;
 
-  if (map?.sourcesContent?.length) {
+  if (map && (!map.sourcesContent || !map.sourcesContent.length)) {
     map.sourcesContent = [source];
   }
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

In our project we use a different loader setting for TypeScript files from what's recommended in the [Recipes](https://github.com/callstack/haul/blob/master/docs/Recipes.md#with-ts-compiler-tsc).
TS files are loaded by `ts-loader` **then** a `babelWorkerLoader` with metro preset:
```
// Ugly experimental code below
const babelLoaderRule = config.module!.rules[1];
const babelLoaderDef = (babelLoaderRule.use as webpack.RuleSetUseItem[])[0] as webpack.RuleSetLoader;
(babelLoaderDef.options! as any).presets = [[require.resolve('metro-react-native-babel-preset'), { disableImportExportTransform: false }]];

config.module!.rules.push({
  test: /\.tsx?$/,
  loader: 'ts-loader',
  options: {
    onlyCompileBundledFiles: true,
    transpileOnly: env.bundleTarget !== 'file',
    compilerOptions: {
      declaration: false,
      sourceMap: true
    }
  }
});
```

So what `babelWorkerLoader` receives as 'sources' is the compiled JS code, with a sourcemap that points back to original TypeScript file. However, `transform.js` then overwrites the result sourcemap with the compiled JS code (because it thinks it's the real source), resulting in the loss of TypeScript code from sourcemap.

By removing the overwrite, this PR preserves the original source that comes before `babelWorkerLoader`.

While our loader setup is somewhat unusual, I'm curious about the reason for the overwrite logic introduced by #689. If this PR is rejected, some explanation would be truly helpful 👍 

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
