### PR TITLE
Fix bundle options query params

### DIFF
--- a/e2e/react_native_0_60x_ts/__tests__/bundleOptions.android.test.ts
+++ b/e2e/react_native_0_60x_ts/__tests__/bundleOptions.android.test.ts
@@ -94,4 +94,32 @@ describe('packager server', () => {
 
     stopServer(instance);
   });
+
+  it('platform: android requesting bundle is working correctly with unspecified query bundle options', async () => {
+    const defaultMinifyOption = false;
+    let instance = await startServerAsync(PORT, TEST_PROJECT_DIR);
+    let results = await fetchBundle(PORT, 'android', {
+      dev: true,
+    });
+    validateBaseBundle(results.bundle, { platform: 'android' });
+    await fetchBundle(PORT, 'android', {
+      dev: true,
+    });
+
+    await fetchBundle(PORT, 'android', {
+      dev: true,
+      minify: defaultMinifyOption,
+    });
+
+    results = await fetchBundle(PORT, 'android', {
+      dev: false,
+    });
+
+    expect(results.response.status).toBe(501);
+    expect(results.bundle.toString()).toEqual(
+      'Changing query params after the bundle has been created is not supported. To see the changes you need to restart the Haul server.'
+    );
+
+    stopServer(instance);
+  });
 });

--- a/e2e/react_native_0_60x_ts/__tests__/bundleOptions.ios.test.ts
+++ b/e2e/react_native_0_60x_ts/__tests__/bundleOptions.ios.test.ts
@@ -94,4 +94,32 @@ describe('packager server', () => {
 
     stopServer(instance);
   });
+
+  it('platform: ios requesting bundle is working correctly with unspecified query bundle options', async () => {
+    const defaultMinifyOption = false;
+    let instance = await startServerAsync(PORT, TEST_PROJECT_DIR);
+    let results = await fetchBundle(PORT, 'ios', {
+      dev: true,
+    });
+    validateBaseBundle(results.bundle, { platform: 'ios' });
+    await fetchBundle(PORT, 'ios', {
+      dev: true,
+    });
+
+    await fetchBundle(PORT, 'ios', {
+      dev: true,
+      minify: defaultMinifyOption,
+    });
+
+    results = await fetchBundle(PORT, 'ios', {
+      dev: false,
+    });
+
+    expect(results.response.status).toBe(501);
+    expect(results.bundle.toString()).toEqual(
+      'Changing query params after the bundle has been created is not supported. To see the changes you need to restart the Haul server.'
+    );
+
+    stopServer(instance);
+  });
 });

--- a/e2e/utils/bundle.ts
+++ b/e2e/utils/bundle.ts
@@ -42,11 +42,21 @@ export function cleanup(projectDir: string) {
 export async function fetchBundle(
   port: number,
   platform: string,
-  options?: { minify: boolean; dev: boolean }
+  options?: { minify?: boolean; dev?: boolean }
 ) {
-  const builtOptions = options
-    ? `?dev=${options.dev}&minify=${options.minify}`
-    : '';
+  let builtOptions = '';
+  if (options) {
+    const queryBundleOptions = [
+      options.dev !== undefined ? { name: 'dev', value: options.dev } : null,
+      options.minify !== undefined
+        ? { name: 'minify', value: options.minify }
+        : null,
+    ]
+      .filter(Boolean)
+      .map(option => `${option!.name}=${option!.value}`)
+      .join('&');
+    builtOptions = `?${queryBundleOptions}`;
+  }
 
   const response = await fetch(
     `http://localhost:${port}/index.${platform}.bundle${builtOptions}`

--- a/e2e/utils/createBuildTimeTestSuite.ts
+++ b/e2e/utils/createBuildTimeTestSuite.ts
@@ -58,7 +58,7 @@ export default function createBuildTimeTestSuite(
         ).toBeTruthy();
       }
 
-      expect(processTime).toBeLessThan(24000);
+      expect(processTime).toBeLessThan(26000);
     });
   });
 }

--- a/fixtures/react_native_with_haul_0_60x/package.json
+++ b/fixtures/react_native_with_haul_0_60x/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "android": "react-native run-android",
+    "ios": "react-native run-ios",
     "start": "node ../../packages/haul-cli/bin/haul.js start",
     "test": "jest",
     "haul": "node ../../packages/haul-cli/bin/haul.js",

--- a/fixtures/react_native_with_haul_0_60x_ts/App.tsx
+++ b/fixtures/react_native_with_haul_0_60x_ts/App.tsx
@@ -17,7 +17,6 @@ import {
 } from 'react-native/Libraries/NewAppScreen';
 
 const App = () => {
-  console.log('dev check', __DEV__);
   return (
     <Fragment>
       <StatusBar barStyle="dark-content" />

--- a/packages/haul-core/src/server/setupCompilerRoutes.ts
+++ b/packages/haul-core/src/server/setupCompilerRoutes.ts
@@ -9,8 +9,8 @@ import Runtime from '../runtime/Runtime';
 import getBundleDataFromURL from '../utils/getBundleDataFromURL';
 
 type Platform = string;
-type BundleOptions = { dev: boolean; minify: boolean; alreadySet?: boolean };
-type QueryBundleOptions = { dev?: boolean; minify?: boolean };
+type BundleOptions = { dev?: boolean; minify?: boolean; alreadySet?: boolean };
+type QueryBundleOptions = Omit<BundleOptions, 'alreadySet'>;
 type PlatformsBundleOptions = {
   [platform in Platform]: BundleOptions;
 };
@@ -219,7 +219,7 @@ function getBundleOptionsFromQuery(
   query: QueryBundleOptions,
   defaultOptions: BundleOptions
 ) {
-  let bundleOptions: Partial<BundleOptions> = {};
+  let bundleOptions: BundleOptions = {};
 
   if (query.minify === true) {
     bundleOptions.minify = true;

--- a/packages/haul-core/src/server/setupCompilerRoutes.ts
+++ b/packages/haul-core/src/server/setupCompilerRoutes.ts
@@ -9,7 +9,8 @@ import Runtime from '../runtime/Runtime';
 import getBundleDataFromURL from '../utils/getBundleDataFromURL';
 
 type Platform = string;
-type BundleOptions = { dev?: boolean; minify?: boolean; alreadySet?: boolean };
+type BundleOptions = { dev: boolean; minify: boolean; alreadySet?: boolean };
+type QueryBundleOptions = { dev?: boolean; minify?: boolean };
 type PlatformsBundleOptions = {
   [platform in Platform]: BundleOptions;
 };
@@ -105,7 +106,10 @@ export default function setupCompilerRoutes(
           hasWarnedDelta = true;
         }
 
-        const bundleOptionsFromQuery = getBundleOptionsFromQuery(request.query);
+        const bundleOptionsFromQuery = getBundleOptionsFromQuery(
+          request.query,
+          cliBundleOptions
+        );
         const isUserChangedOptions = isUserChangedAlreadySetBundleOptions(
           bundleOptions[platform],
           bundleOptionsFromQuery
@@ -207,23 +211,30 @@ function makeResponseFromCompilerResults(
   return response;
 }
 
-function areBundleOptionsSet(bundleOptions: BundleOptions) {
+function areBundleOptionsSet(bundleOptions: QueryBundleOptions) {
   return bundleOptions.dev !== undefined || bundleOptions.minify !== undefined;
 }
 
-function getBundleOptionsFromQuery(query: { minify?: boolean; dev?: boolean }) {
-  let bundleOptions: BundleOptions = {};
+function getBundleOptionsFromQuery(
+  query: QueryBundleOptions,
+  defaultOptions: BundleOptions
+) {
+  let bundleOptions: Partial<BundleOptions> = {};
 
   if (query.minify === true) {
     bundleOptions.minify = true;
   } else if (query.minify === false) {
     bundleOptions.minify = false;
+  } else if (query.minify === undefined) {
+    bundleOptions.minify = defaultOptions.minify;
   }
 
   if (query.dev === true) {
     bundleOptions.dev = true;
   } else if (query.dev === false) {
     bundleOptions.dev = false;
+  } else if (query.dev === undefined) {
+    bundleOptions.dev = defaultOptions.dev;
   }
 
   return bundleOptions;
@@ -231,7 +242,7 @@ function getBundleOptionsFromQuery(query: { minify?: boolean; dev?: boolean }) {
 
 function isUserChangedAlreadySetBundleOptions(
   bundleOptions: BundleOptions,
-  bundleOptionsFromQuery: BundleOptions
+  bundleOptionsFromQuery: QueryBundleOptions
 ) {
   if (areBundleOptionsSet(bundleOptionsFromQuery)) {
     if (bundleOptions.alreadySet) {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
There was an error with unspecified query params (minify or dev) and error was thrown after second request because for the first time bundle options were set but weren't checked. Second request and query params were checked against previously set options + default options. If option wasn't specified then its value was undefined and because we are using default options for check it always will fail.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
Added e2e tests for unspecified options
