### PR TITLE
Fix issue with long asset names generated from pnpm paths

### DIFF
--- a/packages/haul-core/src/webpack/loaders/assetLoader.ts
+++ b/packages/haul-core/src/webpack/loaders/assetLoader.ts
@@ -15,6 +15,9 @@ type Config = {
   publicPath?: string | ((path: string) => string);
 };
 
+const MAX_FILENAME_LENGTH = 120;
+let longNameAssetCount = 1;
+
 async function assetLoader(this: any) {
   this.cacheable();
 
@@ -47,10 +50,16 @@ async function assetLoader(this: any) {
   const assets = path.join('assets', config.bundle ? '' : config.platform);
   const suffix = `(@\\d+(\\.\\d+)?x)?(\\.(${config.platform}|native))?\\.${type}$`;
   const filename = path.basename(filePath).replace(new RegExp(suffix), '');
-  const normalizedName =
+  let normalizedName =
     url.length === 0
       ? filename
       : `${url.replace(pathSepPattern, '_')}_${filename}`;
+  if (normalizedName.length > MAX_FILENAME_LENGTH) {
+    normalizedName =
+      normalizedName.substring(normalizedName.length - MAX_FILENAME_LENGTH) +
+      '_' +
+      (longNameAssetCount++).toString();
+  }
   const longName = `${normalizedName
     .toLowerCase()
     .replace(/[^a-z0-9_]/g, '')}.${type}`;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This PR fixes issue #748 

### Test plan

Example output when compiling react-navigation in a pnpm project:

```
68502 % ls drawable-mdpi/  
gation_stack551_a182da6647d2184b7d281770a34a973a_node_modules_reactnavigation_stack_src_views_assets_backiconmask_3.png
m_reactnative0622_686ec919160581136b28b7fe63160a42_node_modules_reactnative_libraries_logbox_ui_logboximages_loader_6.png
native0622_686ec919160581136b28b7fe63160a42_node_modules_reactnative_libraries_logbox_ui_logboximages_alerttriangle_7.png
native0622_686ec919160581136b28b7fe63160a42_node_modules_reactnative_libraries_logbox_ui_logboximages_chevronright_4.png
navigation_stack551_a182da6647d2184b7d281770a34a973a_node_modules_reactnavigation_stack_src_views_assets_backicon_2.png
pm_reactnative0622_686ec919160581136b28b7fe63160a42_node_modules_reactnative_libraries_logbox_ui_logboximages_close_1.png
```

Might still be an issue if multiple processes or worker threads are running an asset loader module in parallel. Let me know if you'd like a different approach