### PR TITLE
Support node 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@types/lodash.merge": "^4.6.6",
     "@types/lodash.throttle": "^4.1.6",
     "@types/mkdirp": "^0.5.2",
-    "@types/node": "^10.17.13",
+    "@types/node": "^14.14.6",
     "@types/node-fetch": "^2.5.4",
     "@types/npm-registry-fetch": "^4.0.1",
     "@types/pify": "^3.0.2",

--- a/packages/haul-core/src/server/setupDevtoolRoutes.ts
+++ b/packages/haul-core/src/server/setupDevtoolRoutes.ts
@@ -80,7 +80,13 @@ export default function setupDevtoolRoutes(
         filename
       )}\nYou can open the trace report in Google Chrome by navigating to 'chrome://tracing' and clicking 'load'.`;
       try {
-        await promisify(fs.writeFile)(filename, request.payload);
+        await promisify(fs.writeFile)(
+          filename,
+          typeof request.payload === 'string' ||
+            request.payload instanceof Buffer
+            ? request.payload
+            : JSON.stringify(request.payload)
+        );
         runtime.logger.info(message);
       } catch (error) {
         return h.response().code(200);

--- a/packages/haul-core/src/utils/importModule.ts
+++ b/packages/haul-core/src/utils/importModule.ts
@@ -84,9 +84,13 @@ function loadModule(
     )
     .concat(path.dirname(module.filename));
   provided.cache[module.id] = module;
-
+  
   // Create resolver for this module.
-  const currentResolve = ((Module.createRequireFromPath(
+
+  // createRequireFromPath was deprecated in Node v12.2.0, createRequire has taken its place
+  const createRequire = Module.createRequire || Module.createRequireFromPath
+
+  const currentResolve = ((createRequire(
     module.filename
   ) as unknown) as {
     resolve: RequireResolve;

--- a/packages/haul-core/src/utils/importModule.ts
+++ b/packages/haul-core/src/utils/importModule.ts
@@ -84,15 +84,13 @@ function loadModule(
     )
     .concat(path.dirname(module.filename));
   provided.cache[module.id] = module;
-  
+
   // Create resolver for this module.
 
   // createRequireFromPath was deprecated in Node v12.2.0, createRequire has taken its place
-  const createRequire = Module.createRequire || Module.createRequireFromPath
+  const createRequire = Module.createRequire || Module.createRequireFromPath;
 
-  const currentResolve = ((createRequire(
-    module.filename
-  ) as unknown) as {
+  const currentResolve = ((createRequire(module.filename) as unknown) as {
     resolve: RequireResolve;
   }).resolve;
 

--- a/packages/haul-explore/src/index.ts
+++ b/packages/haul-explore/src/index.ts
@@ -89,7 +89,7 @@ const outputFile = argv[outputFormat] || '';
 
 function writeResults(result: ExploreResult) {
   if (outputFile.length > 0) {
-    fs.writeFileSync(outputFile, result.output);
+    fs.writeFileSync(outputFile, result.output || 'undefined');
   } else {
     writeHtmlToTempFile(result.output);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4042,10 +4042,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.4.tgz#f83ec3c3e05b174b7241fadeb6688267fe5b22ca"
   integrity sha512-+rabAZZ3Yn7tF/XPGHupKIL5EcAbrLxnTr/hgQICxbeuAfWtT0UZSfULE+ndusckBItcv4o6ZeOJplQikVcLvQ==
 
-"@types/node@^10.17.13":
-  version "10.17.13"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.13.tgz#ccebcdb990bd6139cd16e84c39dc2fb1023ca90c"
-  integrity sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==
+"@types/node@^14.14.6":
+  version "14.14.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.6.tgz#146d3da57b3c636cc0d1769396ce1cfa8991147f"
+  integrity sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw==
 
 "@types/npm-package-arg@*":
   version "6.1.0"


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
Solves [Module.createRequireFromPath() is deprecated](https://github.com/callstack/haul/issues/746)
Node 14 has made it to long term support, and it crashes when used with Haul. To fix this I've bumped `@types/node` to currtent, and added `Module.createRequire` with fallback to `Module.createRequireFromPath` where only `Module.createRequireFromPath` was used before.
In addition I fixed type errors that came with the `@types/node` update.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan
I'm not sure how best to test, I ran the jest tests locally, and failed 7 test suites, 10 tests, and 3 snapshots on the PR branch vs 10 test suites, 15 tests and 3 snapshots on master. Looks like createRequireFromPath and createRequire are equivalent api equivalent, apart from createRequire supporting URL input, so they should be swappable.

