### PR TITLE
fix: provide original code in source maps when using RAM bundles

### DIFF
--- a/packages/haul-preset-0.59/src/defaultConfig.ts
+++ b/packages/haul-preset-0.59/src/defaultConfig.ts
@@ -37,7 +37,7 @@ export default function getDefaultConfig(
   return {
     mode: dev ? 'development' : 'production',
     context: root,
-    devtool: false,
+    devtool: type === 'basic-bundle' ? false : 'source-map',
     entry: entryFiles,
     output: {
       path: assetsDest || root,

--- a/packages/haul-preset-0.60/src/defaultConfig.ts
+++ b/packages/haul-preset-0.60/src/defaultConfig.ts
@@ -38,7 +38,7 @@ export default function getDefaultConfig(
   return {
     mode: dev ? 'development' : 'production',
     context: root,
-    devtool: false,
+    devtool: type === 'basic-bundle' ? false : 'source-map',
     entry: entryFiles,
     output: {
       path: assetsDest || root,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

When building RAM bundles, there are a couple issues which occur with the source map:
1. The source map contains the transformed source code output of Babel, instead of the original source code.
2. The original file paths in the source map are prefixed with `node_modules/@haul-bundler/core/build/webpack/loaders/babelWorkerLoader/index.js??ref--5-0!`.

Setting the webpack config to use `devtool: 'source-map'`, when building RAM bundles, appears to resolve these issues.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
1. Build a RAM bundle of an RN app with Haul and produce a source map of the bundle. For reference I've included 
[source maps.zip](https://github.com/callstack/haul/files/6174504/source.maps.zip), which includes source maps from the default `react-native init` Android app, both with and without this fix.
2. Examine the content of the source map. To help with this, I threw together [dump-source-map](https://github.com/joeblynch/dump-source-map), which can be used to reconstruct the original source code, as contained in a source map file.

For example, without the fix, the source map will contain:
**/Users/jlynch/tmp/TestRNApp60/node_modules/@haul-bundler/core/build/webpack/loaders/babelWorkerLoader/index.js??ref--5-0!/Users/jlynch/tmp/TestRNApp60/App.js**
```javascript
...
const App = () => {
  return /*#__PURE__*/React.createElement(Fragment, {
    __source: {
      fileName: _jsxFileName,
      lineNumber: 29,
      columnNumber: 5
    }
  }, /*#__PURE__*/React.createElement(StatusBar, {
    barStyle: "dark-content",
    __source: {
      fileName: _jsxFileName,
      lineNumber: 30,
      columnNumber: 7
    }
  }), /*#__PURE__*/React.createElement(SafeAreaView, {
...
```

With the fix, the source map will contain:
**/Users/jlynch/tmp/TestRNApp60/App.js**
```javascript
...
const App = () => {
  return (
    <Fragment>
      <StatusBar barStyle="dark-content" />
...
```